### PR TITLE
Bootstrap initial project docs for AI Outfit Intelligence Platform

### DIFF
--- a/docs/project/agent-operating-model.md
+++ b/docs/project/agent-operating-model.md
@@ -1,0 +1,111 @@
+# Agent Operating Model
+
+## Artifact metadata
+- **Upstream source:** Repository rules, prompts, and GitHub issue #37 master product description.
+- **Bootstrap stage:** Bootstrap support documentation.
+- **Next downstream use:** Board design, stage promotion logic, and approval handling for later artifacts.
+- **Key assumption:** The repository will add staged artifacts after bootstrap, so this operating model must work before boards exist.
+- **Missing decisions:** Specific board schemas can be added later without changing the lifecycle and approval model defined here.
+
+## Purpose
+Define how this repository moves from bootstrap documentation to phased delivery so agents, humans, and automation operate against the same lifecycle, approval rules, and artifact handoffs.
+
+## Source of truth
+- `docs/project/` holds product, standards, architecture, and workflow guidance.
+- `boards/` will hold stage-specific delivery tracking when boards are introduced.
+- GitHub issues and pull requests hold execution history, review discussion, and merge state.
+- `.cursor/prompts/`, `.cursor/rules/`, and `.cursor/skills/` define execution behavior for agents.
+
+## Delivery stages
+
+| Stage | Primary artifact | Purpose | Typical downstream handoff |
+| --- | --- | --- | --- |
+| Bootstrap | Canonical project docs in `docs/project/` | Establish shared product context, scope, roadmap, architecture direction, and standards. | Business requirements and feature breakdown generation. |
+| Business requirements | BR artifact per product area or request | Capture scoped product and business intent for a work item. | Feature breakdown. |
+| Feature breakdown | Feature or capability decomposition | Convert business scope into implementation-oriented feature slices. | Architecture. |
+| Architecture | Technical architecture artifact | Define subsystem boundaries, interfaces, dependencies, and implementation approach. | Implementation plan. |
+| Implementation plan | Workstream plan with dependency map | Split approved architecture into UI, backend, integration, and QA work. | Build stages. |
+| UI / Backend / Integration build | Deliverable-specific build artifacts and code | Execute planned work in parallel where dependencies allow. | QA review. |
+| QA review | Test matrix, validation notes, and go/no-go recommendation | Verify the work against the plan and requirements. | Human approval and release operations. |
+| Release / optimization | Rollout, monitoring, and iteration | Move validated work into production and learn from telemetry. | Follow-on requirements. |
+
+## Lifecycle states
+Use these exact states in boards and stage notes:
+- `TODO`
+- `IN_PROGRESS`
+- `NEEDS_REVIEW`
+- `IN_REVIEW`
+- `CHANGES_REQUESTED`
+- `READY_FOR_HUMAN_APPROVAL`
+- `APPROVED`
+- `DONE`
+
+## Approval modes
+Every stage item should record one approval mode.
+
+| Approval mode | Meaning |
+| --- | --- |
+| `HUMAN_REQUIRED` | A passing review is not enough to fully approve the item. Human approval is required before the item becomes `APPROVED`. |
+| `AUTO_APPROVE_ALLOWED` | A passing review may recommend direct `APPROVED` when rubric thresholds are met and milestone gates are not bypassed. |
+
+## Default approval guidance
+Use these defaults unless a board item or artifact explicitly overrides them.
+
+| Stage | Default approval mode |
+| --- | --- |
+| Bootstrap project docs | `AUTO_APPROVE_ALLOWED` for autonomous bootstrap runs |
+| Business requirements | `HUMAN_REQUIRED` |
+| Feature breakdown | `HUMAN_REQUIRED` |
+| Architecture | `HUMAN_REQUIRED` |
+| Implementation plan | `HUMAN_REQUIRED` |
+| UI / Backend / Integration build | `AUTO_APPROVE_ALLOWED` for implementation readiness, unless a milestone gate says otherwise |
+| QA review | `HUMAN_REQUIRED` before production release |
+
+## Milestone-gate pattern
+Some downstream work should wait for a recorded readiness checkpoint even when work streams are independently reviewable.
+
+Examples:
+- UI readiness reviewed before backend or integration work consumes a shared contract that the UI defines.
+- Data contract approval before experimentation or marketing activation depends on new identity or telemetry logic.
+- QA signoff before production rollout.
+
+Record these gates in the artifact or board Notes rather than leaving them implicit.
+
+## Artifact traceability expectations
+Every artifact should identify:
+- its upstream input artifacts;
+- the next intended downstream artifact or stage;
+- missing decisions that still require resolution;
+- assumptions that shape the current design;
+- the approval mode or governance interpretation if relevant.
+
+## Roles
+
+### Cursor Cloud Agents
+Create and update artifacts, code, tests, and review outputs using repository prompts and rules.
+
+### Cursor Automations
+Trigger intake, review, or pickup suggestions. They must not overclaim approval or completion without the configured evidence.
+
+### GitHub Actions
+Provide deterministic validation such as linting, tests, CI checks, or merge-coupled workflows.
+
+### Humans
+Resolve strategic scope choices, approve stages that require human judgment, and make go or no-go decisions for production rollout.
+
+## What later stages should expect from bootstrap docs
+Bootstrap docs are complete enough when later agents can:
+- derive business requirements for individual capabilities;
+- split the platform into recommendation, data, delivery, and governance work streams;
+- identify major surfaces, integrations, and telemetry requirements;
+- understand where decisions are still open instead of guessing.
+
+## Missing-decision handling
+When the repository lacks a decision that affects scope, governance, or implementation direction:
+1. record it explicitly as a missing decision;
+2. keep the current artifact internally consistent without pretending the decision is settled;
+3. point to the stage where the decision should be resolved;
+4. do not silently widen or narrow scope downstream.
+
+## Practical operating rule for this bootstrap repository state
+This repository is still in the product-definition stage. Until boards and feature-level artifacts exist, `docs/project/` is the authoritative operating layer for product direction, review criteria, and future stage handoffs.

--- a/docs/project/api-standards.md
+++ b/docs/project/api-standards.md
@@ -1,0 +1,48 @@
+# API Standards
+
+## Artifact metadata
+- **Upstream source:** GitHub issue #37 master product description plus bootstrap architecture and standards docs.
+- **Bootstrap stage:** Bootstrap project documentation.
+- **Next downstream use:** Recommendation API architecture, integration planning, and channel contract design.
+- **Key assumption:** Shared recommendation APIs will be the primary delivery contract across multiple channels.
+- **Missing decisions:** Final API versioning and auth patterns should be set during capability architecture and integration planning.
+
+## Purpose
+Define API expectations for services that deliver recommendations, operator controls, and related platform data.
+
+## API style
+- Prefer resource-oriented HTTP APIs with JSON payloads for synchronous recommendation delivery.
+- Use explicit endpoint naming that reflects the product domain, for example `/recommendations` for delivery and separate operator-facing endpoints for rules, looks, or experiments.
+- Keep request contracts explicit about context inputs such as `customerId`, `productId`, `surface`, `locale`, `weather`, and session metadata when applicable.
+
+## Response structure expectations
+- Allow multiple recommendation groups in a single response, such as `outfits`, `crossSell`, `upsell`, and `styleBundles`.
+- Include stable identifiers for the recommendation set, trace context, and experiment assignment when relevant.
+- Return both item references and enough metadata for consumers to render or fetch display details safely.
+- Represent empty results explicitly rather than overloading error responses.
+
+## Versioning
+- Use explicit versioning for externally consumed contracts, ideally URI or header based, and document the chosen pattern consistently.
+- Treat contract-breaking changes as versioned changes, not silent drift.
+- Maintain backward compatibility during channel migrations where feasible.
+
+## Error model
+- Use a predictable error envelope with machine-readable codes, human-readable messages, and trace identifiers.
+- Distinguish between invalid request, unauthorized access, upstream dependency failure, timeout, and empty eligible-result cases.
+- Do not treat "no recommendation available" as a server error when fallback behavior is expected.
+
+## Authentication and authorization
+- Customer-facing recommendation requests should use channel-appropriate service authentication rather than exposing privileged internal credentials.
+- Operator-facing APIs must enforce role-based access controls for rules, curation, experiments, and governance-sensitive actions.
+- Audit operator mutations that change live recommendation behavior.
+
+## Contract consistency rules
+- Field names should be stable, descriptive, and consistent across channels.
+- All IDs in API contracts should map to canonical identifiers defined in `data-standards.md`.
+- Recommendation responses should preserve enough context to join downstream telemetry with the original decision.
+- Avoid embedding channel-specific business logic in shared API contracts.
+
+## Resilience expectations
+- Define request timeouts appropriate for synchronous customer-facing use.
+- Support idempotency for write operations that mutate rules or curated look state.
+- Publish clear fallback expectations when the platform cannot produce a recommendation set in time.

--- a/docs/project/architecture-overview.md
+++ b/docs/project/architecture-overview.md
@@ -1,0 +1,128 @@
+# Architecture Overview
+
+## Artifact metadata
+- **Upstream source:** GitHub issue #37 master product description plus bootstrap product docs.
+- **Bootstrap stage:** Bootstrap project documentation.
+- **Next downstream use:** Capability-level architecture artifacts, implementation planning, and integration scoping.
+- **Key assumption:** The first architecture slice should support a PDP RTW rollout while keeping the domain model extensible for later personalization, operator tooling, and CM growth.
+- **Approval note:** Later architecture artifacts should default to `HUMAN_REQUIRED`, especially where identity, privacy, or external integration trade-offs are still open.
+
+## Purpose
+Describe the high-level system shape for the AI Outfit Intelligence Platform so later architecture artifacts can decompose the platform into feature- and service-level designs without redefining the core boundaries.
+
+## High-level system view
+The platform should sit between source systems and recommendation-consuming channels.
+
+1. **Source systems** provide product, inventory, order, customer, marketing, and store-interaction data.
+2. **Ingestion and normalization** turns source data into canonical catalog, customer, context, and event records.
+3. **Intelligence services** build relationship graphs, customer profiles, context signals, and recommendation candidates.
+4. **Decision and delivery services** apply rules, rank candidates, and serve recommendation sets through APIs.
+5. **Channel surfaces and operator tools** consume recommendation output and feed back performance and override signals.
+
+## Major subsystem areas
+
+### 1. Catalog and inventory ingestion
+Responsible for:
+- product attributes across RTW and CM;
+- imagery and style tags;
+- inventory and availability status;
+- source-to-canonical product ID mapping.
+
+### 2. Event and customer signal pipeline
+Responsible for:
+- browsing, search, product-view, cart, order, email-engagement, appointment, and clienteling signals;
+- event normalization and schema enforcement;
+- session stitching and channel-source attribution.
+
+### 3. Identity resolution and profile service
+Responsible for:
+- linking anonymous and known customer identifiers;
+- storing profile attributes, purchase affinities, and segmentation outputs;
+- exposing confidence-scored identity resolution results to downstream consumers.
+
+**Bootstrap direction:** Treat the recommendation profile service as the canonical serving layer for recommendation decisions, with mapped source identities from commerce, CRM, POS, and clienteling systems feeding it.
+
+### 4. Product relationship and outfit graph
+Responsible for:
+- compatibility relationships across categories;
+- curated looks and look-to-product membership;
+- business-rule metadata such as exclusions, priorities, and campaign overlays;
+- RTW and CM compatibility differences.
+
+### 5. Context engine
+Responsible for:
+- season, weather, location, market, and occasion enrichment;
+- session-level context signals usable in recommendation requests;
+- graceful fallback when context data is incomplete.
+
+### 6. Recommendation engine
+Responsible for:
+- candidate retrieval from curated, rule-based, and learned sources;
+- scoring and ranking of outfits, cross-sell, upsell, and style bundles;
+- balancing relevance, availability, and merchandising controls;
+- producing explanation metadata for internal debugging and analytics.
+
+### 7. Recommendation delivery API
+Responsible for:
+- receiving request context such as customer ID, product ID, locale, weather, and surface type;
+- returning recommendation groups in a channel-consumable contract;
+- passing recommendation-set IDs, trace IDs, and experiment metadata for telemetry;
+- meeting latency and reliability needs for customer-facing surfaces.
+
+### 8. Merchandising and governance tools
+Responsible for:
+- curated look authoring or import workflows;
+- rule management for inclusion, exclusion, and override logic;
+- experiment and campaign configuration;
+- auditability and access control for sensitive operations.
+
+### 9. Analytics and observability
+Responsible for:
+- recommendation event telemetry;
+- performance dashboards and experiment readouts;
+- operational monitoring for API health, data freshness, and model or rule outcomes.
+
+## Data flow overview
+1. Source data arrives from commerce, OMS, POS, CRM, email, clienteling, and context providers.
+2. Normalization pipelines create canonical records for products, customers, events, and context dimensions.
+3. Relationship modeling and profiling services update look structures, affinities, and segmentation outputs.
+4. A consuming surface calls the recommendation API with user, product, and context inputs.
+5. The recommendation engine retrieves eligible candidates, applies rules, scores results, and returns structured recommendation sets.
+6. The surface renders those sets and emits telemetry events tied to recommendation-set and trace identifiers.
+7. Analytics and experimentation systems evaluate outcomes and feed future optimization.
+
+## External integrations
+Likely integrations include:
+- Shopify or other commerce catalog and order systems;
+- OMS or inventory sources;
+- POS or clienteling systems for store interactions;
+- CRM, loyalty, or account systems;
+- email marketing or campaign tools;
+- weather or locale-context providers;
+- analytics and experimentation platforms.
+
+## Technical boundaries
+- Recommendation logic should depend on canonical product, context, and profile inputs rather than channel-specific schemas.
+- Channel surfaces should not embed their own incompatible ranking logic when a shared platform contract exists.
+- Merchandising overrides should constrain recommendation eligibility and ranking without bypassing traceability.
+- Identity confidence, consent state, and inventory availability should be treated as first-class inputs, not optional afterthoughts.
+
+## Operational assumptions
+- Some recommendation requests will run for anonymous users and must rely on session and context signals only.
+- Some source data will arrive with latency or incompleteness, so freshness tracking and fallback behavior are required.
+- The platform will likely need hybrid batch and near-real-time processing: batch for relationship modeling and profile aggregation, near real time for session context and delivery.
+
+## Implementation-oriented constraints
+- The API contract must support multiple recommendation groups in one response.
+- Telemetry must preserve recommendation-set IDs, trace IDs, rule context, and experiment context so results are auditable.
+- Data models must represent both product-level items and multi-item looks.
+- CM support must not be bolted on later in a way that breaks the product model; the domain model should account for configurable garments from the start.
+- Observability must cover freshness, latency, empty-result rate, and override frequency.
+
+## Missing decisions
+
+| Missing decision | Why it matters | Temporary bootstrap direction | Proposed resolution stage | Recommended owner |
+| --- | --- | --- | --- | --- |
+| Repository or deployment topology for the eventual platform services | Shapes service ownership, scaling, and release boundaries. | Keep this overview deployment-agnostic until feature-level architecture exists. | Capability architecture artifacts and implementation planning. | Architecture owners. |
+| Whether the relationship graph is implemented as graph-native storage, relational structures, or a hybrid model | Impacts performance, maintainability, and operator workflows. | Model relationships abstractly now and choose storage during architecture decomposition. | Product-relationship and recommendation-architecture work. | Architecture and data-platform owners. |
+| Where experimentation assignment lives if existing company tooling already handles it | Affects API design and telemetry joins. | Keep experiment context as an input and output contract requirement regardless of assignment location. | Recommendation API and experimentation architecture. | Product analytics and architecture owners. |

--- a/docs/project/business-requirements.md
+++ b/docs/project/business-requirements.md
@@ -1,0 +1,152 @@
+# Business Requirements
+
+## Artifact metadata
+- **Upstream source:** GitHub issue #37 master product description.
+- **Bootstrap stage:** Bootstrap project documentation.
+- **Next downstream use:** Initial BR fan-out, feature breakdown, and product-level architecture decomposition.
+- **Key assumption:** The first delivery slice should prove high-intent outfit recommendation value on one ecommerce surface before broad multi-channel rollout.
+- **Approval note:** This bootstrap requirement layer informs later narrower BR artifacts; those follow-on artifacts should default to `HUMAN_REQUIRED`.
+
+## Purpose
+Define the initial product-wide business requirements for the AI Outfit Intelligence Platform so later feature and architecture work can decompose the platform without reinterpreting the master product description.
+
+## Problem to solve
+SuitSupply needs a platform that can recommend complete outfits, not only isolated products, while respecting style compatibility, occasion, weather, customer profile, and merchandising intent across multiple channels.
+
+## Target users
+### Primary users
+- Online shoppers browsing suits, shirts, shoes, accessories, and looks.
+- Returning customers with purchase history and style signals.
+- Occasion-led customers shopping for weddings, business, travel, interviews, and seasonal refresh needs.
+
+### Secondary users
+- In-store stylists and clienteling teams.
+- Merchandisers curating looks, rules, and campaigns.
+- Marketing teams using recommendations in outbound channels.
+- Product, analytics, and optimization teams measuring performance.
+
+## Business value
+The platform should create measurable value through:
+- higher conversion rate;
+- higher basket size and attachment rate;
+- stronger repeat purchase behavior and customer lifetime value;
+- better discovery and style inspiration;
+- stronger merchandising leverage and control;
+- better performance of email and clienteling workflows;
+- stronger differentiation versus recommendation systems that only optimize product similarity.
+
+## Success measures
+### Commercial targets
+- Conversion increase target: +5% to +10%.
+- Average order value increase target: +10% to +25%.
+- Improved engagement and repeat purchase behavior.
+- Improved recommendation performance in personalized email and clienteling workflows.
+
+### Platform effectiveness signals
+- Recommendation-assisted revenue share.
+- Multi-category basket formation rate.
+- Recommendation acceptance metrics by surface and type.
+- Operator launch and override efficiency.
+- Telemetry completeness for impression-to-outcome analysis.
+
+## In-scope capabilities
+- Product catalog ingestion for RTW and CM attributes.
+- Customer-signal ingestion from commerce, browsing, search, email, loyalty, appointments, and stylist signals where available.
+- Context-signal ingestion including location, country, weather, season, and relevant event calendar inputs.
+- Identity resolution and customer profile services.
+- Purchase affinity, segmentation, and intent detection.
+- Product relationship graph and outfit graph or curated look model.
+- Compatibility rules, merchandising rules, and governance controls.
+- Recommendation engine and context engine.
+- Recommendation delivery API.
+- Recommendation widgets or channel integrations for the named surfaces.
+- Experimentation, analytics, and insights.
+- Admin or merchandising interfaces needed to operate the system.
+
+## In-scope recommendation types
+- Outfit recommendations
+- Cross-sell recommendations
+- Upsell recommendations
+- Curated style bundles
+- Occasion-based recommendations
+- Contextual recommendations
+- Personal recommendations based on customer profile and behavior
+
+## In-scope surfaces
+- Product detail pages
+- Cart
+- Homepage and web personalization
+- Style inspiration or look-builder pages
+- Email campaigns
+- In-store clienteling interfaces
+- Future mobile or API-driven surfaces, provided the shared API supports them
+
+## Recommended first delivery slice
+To keep downstream fan-out bounded, the repository should treat this as the default first implementation slice unless a later BR explicitly supersedes it:
+- **Primary surface:** Product detail page complete-the-look for RTW tailoring anchor products.
+- **Initial recommendation types:** Outfit recommendations plus closely related cross-sell complements.
+- **Initial market approach:** Single pilot market or tightly controlled rollout cohort before broader expansion.
+- **Identity approach for phase one:** A recommendation profile service owns the canonical recommendation profile, seeded by commerce customer IDs and anonymous session IDs; CRM, POS, and clienteling identities are linked as mapped sources rather than primary authorities in the first slice.
+- **Merchandising operating approach:** Start with curated looks and explicit exclusion or priority rules, with lightweight operator workflows before a full merchandising admin surface matures.
+- **CM handling in the first slice:** Preserve CM-compatible modeling in the domain design, but defer deep CM configuration guidance until later phases unless a narrower CM pilot is separately approved.
+
+## Recommended first downstream BR fan-out candidates
+The canonical execution order for the first downstream BR artifacts is:
+1. **BR-002:** Catalog, event, identity, and recommendation telemetry foundation.
+2. **BR-003:** Product relationship graph, curated looks, and merchandising-rule controls.
+3. **BR-004:** Recommendation delivery API and trace contract.
+4. **BR-001:** PDP RTW outfit recommendation experience.
+5. **BR-005:** Returning-customer personalization and clienteling or email activation after the first ecommerce slice proves out.
+
+## RTW and CM requirements
+### RTW
+The platform must support standard product and outfit recommendations that account for category compatibility, inventory, seasonality, and customer context.
+
+### CM
+The platform must support recommendation logic for shirt styles, tie styles, color palettes, fabric combinations, premium options, and compatibility with customer-configured garments or consultation flows.
+
+## Major workflows
+1. Ingest and normalize catalog, inventory, customer, and context data.
+2. Resolve customer identity and session context across channels.
+3. Build or update product relationships, outfit compatibility, and curated look structures.
+4. Generate recommendation sets appropriate to a customer, product, occasion, and context.
+5. Deliver recommendation sets to online, assisted-selling, and marketing surfaces.
+6. Capture recommendation telemetry and operator actions for optimization and governance.
+
+## Constraints
+- The platform must preserve merchandising control and business-rule override capability.
+- Customer data use must respect consent, regional privacy requirements, and channel-specific permissions.
+- Recommendation output must work across both anonymous and known-customer contexts.
+- Inventory and product availability constraints must prevent broken recommendations on customer-facing surfaces.
+- The initial architecture must support phased rollout rather than requiring every capability in one launch.
+
+## Assumptions
+- SuitSupply has or can expose catalog, order, event, and customer-source data needed for the initial phases.
+- Weather, location, and event-context enrichment can be sourced through internal or external providers.
+- Merchandising teams are willing to define curated looks, rules, and governance policies needed to bootstrap recommendation quality.
+- Channel teams can consume a shared recommendation API rather than each channel owning isolated logic.
+
+## Out of scope for the bootstrap-defined platform
+- Full re-platforming of commerce, POS, CRM, or marketing systems.
+- Replacing human styling with fully automated decisioning.
+- Building unrelated editorial CMS, checkout, or loyalty products.
+- Guaranteeing that all channels launch simultaneously.
+
+## Governance notes
+- Recommendation reasoning should be auditable internally, but customer-facing surfaces should avoid exposing sensitive profile inference.
+- Identity resolution confidence and consent state must be available wherever personalization depends on them.
+- Human and deterministic controls must remain available for exclusions, campaign priorities, and policy-sensitive use cases.
+
+## Open questions and missing decisions
+
+| Missing decision | Why it matters | Temporary bootstrap direction | Proposed resolution stage | Recommended owner |
+| --- | --- | --- | --- | --- |
+| Phase-one channel scope beyond PDP | Controls how many channel integrations enter the first architecture slice. | Default to PDP first; add cart or inspiration only through a later BR decision. | First downstream BR fan-out. | Product and ecommerce leadership. |
+| Phase-one market scope | Affects context rules, rollout safety, and experimentation design. | Default to a pilot market or controlled cohort. | First downstream BR fan-out and rollout planning. | Product, merchandising, and regional business owners. |
+| System of record for recommendation profiles and identity stitching | Central dependency for personalization and cross-channel continuity. | Use a dedicated recommendation profile service as the canonical serving layer, with mapped source identities from commerce, CRM, POS, and clienteling systems. | Architecture for the identity and profile foundation. | Product, data platform, and architecture owners. |
+| Depth of CM support in early phases | Determines whether CM enters the first live surface or later platform phases. | Keep CM in the domain model now, but defer deep CM guidance until later unless a separate BR narrows it. | BR and roadmap refinement before Phase 3 execution. | Product and CM business owners. |
+| Merchandising operating model for curated looks, exclusions, and experiments | Determines operator workflows and governance boundaries. | Start with lightweight curated-look and rule-management workflows before a richer admin interface. | BR and architecture for merchandising tools. | Merchandising and product operations. |
+| External providers for weather, holiday, or event enrichment | Affects context engine design and integration cost. | Treat these as pluggable enrichments with graceful fallback. | Architecture and integration planning. | Architecture and integration owners. |
+
+## Approval and workflow note
+This document is the bootstrap product-wide requirement layer. Later phases should create narrower BR artifacts per capability or delivery slice before architecture or implementation work begins.

--- a/docs/project/data-standards.md
+++ b/docs/project/data-standards.md
@@ -1,0 +1,81 @@
+# Data Standards
+
+## Artifact metadata
+- **Upstream source:** GitHub issue #37 master product description plus bootstrap architecture and standards docs.
+- **Bootstrap stage:** Bootstrap project documentation.
+- **Next downstream use:** Data-model design, telemetry implementation, identity architecture, and analytics planning.
+- **Key assumption:** Recommendation quality depends on canonical identifiers and consistent telemetry across channels.
+- **Missing decisions:** Data ownership assignments and some source-system mappings should be finalized during data and identity architecture work.
+
+## Purpose
+Define cross-cutting data expectations for product, customer, event, context, and recommendation telemetry used by the AI Outfit Intelligence Platform.
+
+## Core principles
+- Use stable canonical identifiers for products, customers, looks, campaigns, rules, experiments, and recommendation sets.
+- Preserve source-system mappings so the platform can reconcile commerce, POS, CRM, and marketing data safely.
+- Separate raw source data from normalized canonical records.
+- Record identity resolution confidence whenever signals from multiple systems are stitched together.
+- Treat consent and regional privacy state as required decision inputs for personalization.
+
+## Canonical identifiers
+At minimum, the platform should define:
+- `productId`
+- `variantId` where applicable
+- `lookId`
+- `customerId`
+- `sessionId`
+- `recommendationSetId`
+- `traceId`
+- `ruleId`
+- `campaignId`
+- `experimentId`
+
+Every identifier should have a documented owner and source mapping rule.
+
+## Product and look data expectations
+- Product records should cover category, fabric, color, pattern, fit, season, occasion, style tags, price tier, imagery, inventory state, and RTW or CM-specific attributes.
+- Look records should represent a modeled compatible set of products, not only an ad hoc UI grouping.
+- CM entities should support configurable options without breaking canonical product and look relationships.
+
+## Event taxonomy
+Recommendation telemetry should at minimum support these event types:
+- impression
+- click
+- save
+- add-to-cart
+- purchase
+- dismiss
+- override
+
+Each event should carry, where applicable:
+- `recommendationSetId`
+- `traceId`
+- `surface`
+- `recommendationType`
+- `lookId` or product references
+- experiment context
+- rule context
+- session and customer identifiers with confidence or consent context as needed
+
+## Event consistency rules
+- Emit recommendation events from every surface using the same base schema.
+- Timestamp events in a standard timezone format and record event source.
+- Distinguish user actions from operator actions.
+- Preserve ordering or causality information where it matters for analysis.
+- Validate schemas before ingestion into downstream analytics stores.
+
+## Identity and privacy expectations
+- Do not assume one channel identifier is globally reliable without mapping logic.
+- Record identity confidence when linking anonymous and known profiles.
+- Do not use personalization signals when consent or regional policy does not allow it.
+- Avoid storing or exposing unnecessary sensitive inferences in customer-facing contexts.
+
+## Data quality and auditability
+- Track freshness of catalog, inventory, customer, and context feeds.
+- Monitor schema drift, null-rate spikes, and source-mapping failures.
+- Keep change history for curated looks, rules, and operator overrides.
+- Ensure recommendation outcomes can be audited back to the decision context that produced them.
+
+## Ownership expectations
+- Define data owners for catalog, customer identity, recommendation logic, and analytics datasets before production rollout.
+- Record whether each critical data element is source-of-truth, derived, or operational cache data.

--- a/docs/project/goals.md
+++ b/docs/project/goals.md
@@ -1,0 +1,61 @@
+# Goals
+
+## Artifact metadata
+- **Upstream source:** GitHub issue #37 master product description.
+- **Bootstrap stage:** Bootstrap project documentation.
+- **Next downstream use:** Phase prioritization in later BR artifacts, feature breakdowns, and launch-goal definitions.
+- **Key assumption:** Commercial uplift targets are directional targets for planning, not yet launch-gate thresholds.
+- **Approval note:** Bootstrap docs are auto-approvable for this autonomous setup, but downstream BR and architecture artifacts should default to `HUMAN_REQUIRED` unless explicitly changed.
+
+## Business goals
+
+| Goal | Why it matters | Initial success signal |
+| --- | --- | --- |
+| Increase conversion rate | Better outfit guidance should reduce decision friction and drop-off. | Conversion lift within the expected +5% to +10% target range. |
+| Increase average order value | Complete-look recommendations should increase multi-category basket formation. | AOV lift within the expected +10% to +25% target range. |
+| Increase customer lifetime value | Better personalization and inspiration should improve repeat purchase behavior. | Higher repeat purchase rate and stronger recommendation-assisted revenue share. |
+| Improve marketing and clienteling performance | Shared recommendation logic should make email and stylist workflows more relevant. | Better click-through, appointment conversion, and assisted-sales outcomes. |
+| Preserve merchandising control while scaling personalization | Teams need predictable control over campaigns, exclusions, and brand presentation. | High operator adoption with limited manual override churn. |
+
+## User goals
+- Build a complete outfit from a starting product or occasion.
+- Receive recommendations that match season, location, weather, and purpose.
+- See suggestions that respect personal style, prior purchases, and budget positioning.
+- Move smoothly between browsing, cart building, inspiration, and assisted selling experiences.
+- For CM customers, receive guidance on compatible fabrics, colors, style details, and premium options.
+
+## Operational goals
+- Establish a shared product and customer data foundation for recommendation use cases.
+- Support recommendation delivery across ecommerce, clienteling, and marketing channels from one platform.
+- Give merchandisers tools to curate looks, define rules, and govern exceptions without engineering changes for every campaign.
+- Enable experimentation, analytics, and traceable recommendation telemetry so the team can optimize with evidence.
+- Maintain governance for identity, consent, and recommendation explainability boundaries.
+
+## Success criteria
+
+### Outcome metrics
+- Conversion lift attributable to recommendation surfaces.
+- Basket size and attachment-rate lift for recommendation-assisted sessions.
+- Recommendation-driven revenue and repeat purchase impact.
+- Engagement lift on email and clienteling recommendation workflows.
+
+### Product and operational readiness metrics
+- Coverage of core categories required to build complete looks.
+- Recommendation latency and availability suitable for customer-facing surfaces.
+- Measured precision or acceptance of recommendations across RTW and CM contexts.
+- Operator ability to launch or adjust curated looks and rules without code changes.
+- Experiment throughput and telemetry completeness for recommendation events.
+
+## Non-goals
+- Replacing human stylists or merchandising judgment with a fully autonomous system.
+- Building a generic marketplace recommendation engine outside SuitSupply's tailoring and styling domain.
+- Solving unrelated commerce platform replacement work such as checkout redesign or OMS migration.
+- Delivering every channel and every recommendation type in the first release.
+- Exposing detailed customer-profile reasoning or sensitive inference directly to customers.
+
+## Missing decisions
+
+| Missing decision | Why it matters | Proposed resolution stage | Recommended owner |
+| --- | --- | --- | --- |
+| Which success metrics and baselines become launch gates versus longer-term optimization metrics? | Later phases need objective go or no-go criteria. | First capability-specific BR artifacts and implementation planning. | Product and analytics leads. |
+| Should early rollout prioritize one geography, one surface, or one product family for controlled learning? | The roadmap and first fan-out scope depend on it. | Bootstrap follow-on BR fan-out, before architecture for the first slice. | Product, merchandising, and channel leadership. |

--- a/docs/project/integration-standards.md
+++ b/docs/project/integration-standards.md
@@ -1,0 +1,43 @@
+# Integration Standards
+
+## Artifact metadata
+- **Upstream source:** GitHub issue #37 master product description plus bootstrap architecture and standards docs.
+- **Bootstrap stage:** Bootstrap project documentation.
+- **Next downstream use:** Integration architecture, dependency mapping, and rollout planning.
+- **Key assumption:** The platform will depend on multiple internal and external systems, so failure handling and ownership must be explicit from the start.
+- **Missing decisions:** Final provider choices and environment strategies should be resolved during integration architecture and implementation planning.
+
+## Purpose
+Define standards for integrating the recommendation platform with commerce, customer, marketing, context, and analytics systems.
+
+## Integration principles
+- Prefer explicit contracts and ownership boundaries over implicit field sharing.
+- Normalize upstream data into canonical platform models before downstream recommendation logic depends on it.
+- Keep integration responsibilities visible: source owner, transport, cadence, schema, retry policy, and failure behavior.
+- Design for phased rollout so one integration can fail or lag without collapsing the entire platform.
+
+## Authentication and secret handling
+- Use managed secrets and environment configuration rather than hard-coded credentials.
+- Apply least-privilege access for upstream reads and operator-facing writes.
+- Rotate credentials according to platform or provider policy.
+
+## Reliability expectations
+- Define timeouts, retry rules, and circuit-breaker behavior for every synchronous dependency.
+- Use idempotent processing where duplicate source events or retries are possible.
+- Distinguish transient upstream failures from persistent schema or permission failures.
+- Provide fallback behavior for missing non-critical context signals such as weather.
+
+## Observability
+- Monitor availability, latency, freshness, and error rates for each major integration.
+- Include source-system identifiers and trace context in logs or metrics where safe.
+- Alert on ingestion stalls, schema drift, and elevated recommendation empty-result rates caused by integration failures.
+
+## Dependency management
+- Document the owner and contact path for every external or cross-team dependency before production rollout.
+- Version integration contracts where breaking changes are possible.
+- Keep sandbox or test-environment assumptions explicit for QA and rollout planning.
+
+## Data handling expectations
+- Respect consent, privacy, and residency rules for customer data crossing system boundaries.
+- Do not duplicate sensitive customer data into more systems than the use case requires.
+- Record when an integration provides source-of-truth data versus convenience copies or enrichments.

--- a/docs/project/new-project-bootstrap-implementation-spec.md
+++ b/docs/project/new-project-bootstrap-implementation-spec.md
@@ -1,0 +1,66 @@
+# New Project Bootstrap Implementation Spec
+
+## Artifact metadata
+- **Upstream source:** Repository bootstrap prompts and GitHub issue #37 master product description.
+- **Bootstrap stage:** Bootstrap support documentation.
+- **Next downstream use:** Future bootstrap runs and validation of required bootstrap outputs.
+- **Key assumption:** New-project bootstrap may need to create directly required support docs when a fresh repository does not yet contain them.
+- **Missing decisions:** No additional bootstrap-only decisions remain beyond the product-scope questions tracked in the main project docs.
+
+## Purpose
+Define what a bootstrap run must produce in this repository when the project starts from a single master product description and no canonical `docs/project/` layer exists yet.
+
+## Scope of the bootstrap run
+The bootstrap run should create the minimum document set needed for later agents to work responsibly.
+
+### Required canonical docs
+- `vision.md`
+- `goals.md`
+- `problem-statement.md`
+- `personas.md`
+- `product-overview.md`
+- `business-requirements.md`
+- `roadmap.md`
+- `architecture-overview.md`
+- `standards.md`
+
+### Required supporting docs when absent but referenced by prompts or rules
+- `review-rubrics.md`
+- `agent-operating-model.md`
+
+### Conditional standards docs
+Create these during bootstrap when the product clearly depends on them:
+- `api-standards.md`
+- `data-standards.md`
+- `ui-standards.md`
+- `integration-standards.md`
+
+## What bootstrap docs must enable
+Later agents should be able to:
+- write business requirements for distinct capabilities without restating the entire product;
+- derive feature areas and architecture candidates;
+- understand phase order and why it exists;
+- respect data, privacy, and identity constraints;
+- know how review, approval, and traceability are supposed to work.
+
+## Authoring expectations
+- Be implementation-oriented rather than promotional.
+- Use consistent domain language: look, outfit, recommendation, style profile, merchandising rule, RTW, CM.
+- Call out assumptions and missing decisions explicitly.
+- Avoid downstream issue fan-out, sub-feature specs, or board seeding in the bootstrap run.
+- Keep architecture high level but concrete enough for later decomposition.
+
+## Review expectations
+A bootstrap run should include an internal consistency pass covering:
+- vision versus goals;
+- problem statement versus personas;
+- product overview versus business requirements;
+- roadmap versus architecture sequence;
+- standards versus product and architecture shape.
+
+## Completion criteria
+The bootstrap run is complete when:
+- the required docs exist under `docs/project/`;
+- the docs are coherent as a set;
+- the biggest unresolved decisions are recorded rather than implied;
+- the branch is committed, pushed, and ready for downstream phased delivery work.

--- a/docs/project/new-project-bootstrap-to-phased-agent-delivery.md
+++ b/docs/project/new-project-bootstrap-to-phased-agent-delivery.md
@@ -1,0 +1,67 @@
+# New Project Bootstrap To Phased Agent Delivery
+
+## Artifact metadata
+- **Upstream source:** Repository bootstrap prompts and GitHub issue #37 master product description.
+- **Bootstrap stage:** Bootstrap support documentation.
+- **Next downstream use:** BR fan-out ordering and phased delivery interpretation.
+- **Key assumption:** Downstream work should follow the same phase order as `roadmap.md`.
+
+## Purpose
+Explain how the initial bootstrap document layer should be used to transition this repository from a single product-definition issue into a staged delivery workflow.
+
+## Bootstrap input
+The bootstrap run starts from one master product description. That source should define:
+- the problem to solve;
+- the user and operator groups involved;
+- target business value;
+- in-scope recommendation types and surfaces;
+- major data and integration needs;
+- major product constraints or open questions.
+
+## Bootstrap output
+The bootstrap stage should leave the repository with a coherent `docs/project/` layer that covers:
+- vision and goals;
+- problem and personas;
+- product overview and business requirements;
+- roadmap and architecture overview;
+- standards for delivery, data, APIs, UI, and integrations when applicable;
+- review and operating guidance needed by later agents.
+
+## Transition to phased delivery
+After bootstrap, later work should proceed in order.
+
+| Transition | Purpose | Output |
+| --- | --- | --- |
+| Bootstrap -> Business requirements | Break the platform into scoped work items that fit later review and build stages. | BR artifacts tied to one capability, workflow, or rollout increment. |
+| Business requirements -> Feature breakdown | Decompose BR scope into complete features and sub-capabilities. | Feature maps and explicit boundaries. |
+| Feature breakdown -> Architecture | Turn a feature or capability set into system boundaries and contracts. | Architecture artifact with interfaces and dependencies. |
+| Architecture -> Implementation plan | Create execution-ready work streams and sequencing. | Implementation plan with UI, backend, integration, and QA tracks. |
+| Implementation plan -> Build stages | Execute code and configuration changes. | Build deliverables, tests, and integration notes. |
+| Build stages -> QA review | Validate end-to-end behavior and release readiness. | QA artifact and disposition. |
+
+## Bootstrap quality bar for later phase generation
+Bootstrap docs are sufficient only when they let a later agent answer these questions without guessing:
+- What exact user and business outcomes matter?
+- Which recommendation types and channels are in scope?
+- Which product capabilities are foundational versus later-phase?
+- What data, identity, and governance constraints must architecture respect?
+- What open decisions still need human resolution?
+
+## Recommended early phase breakdown for this repository
+For the AI Outfit Intelligence Platform, later phase generation should follow the same ordering used in `roadmap.md`:
+1. Phase 1: product data, event, identity, and telemetry foundation;
+2. Phase 1 to Phase 2: recommendation graph, curated looks, and merchandising-rule controls;
+3. Phase 2: recommendation engine, context engine, and delivery API;
+4. Phase 3: initial online rollout, starting with PDP RTW outfit recommendation;
+5. Phase 4: personalization, operator tooling, clienteling, email activation, and experimentation maturity;
+6. Phase 5: deeper CM recommendation depth and more advanced contextual sophistication.
+
+## Canonical first fan-out candidates
+Until a later artifact supersedes this ordering, the first downstream BR candidates should be:
+1. BR-002: catalog, event, identity, and recommendation telemetry foundation;
+2. BR-003: product relationship graph, curated looks, and merchandising-rule controls;
+3. BR-004: recommendation delivery API and trace contract;
+4. BR-001: PDP RTW outfit recommendation experience.
+
+## Practical handoff rule
+Do not skip from bootstrap directly to implementation. A feature- or capability-level BR and architecture chain is still required before code delivery.

--- a/docs/project/personas.md
+++ b/docs/project/personas.md
@@ -1,0 +1,120 @@
+# Personas
+
+## Artifact metadata
+- **Upstream source:** GitHub issue #37 master product description.
+- **Bootstrap stage:** Bootstrap project documentation.
+- **Next downstream use:** Persona coverage for later BR, UI, personalization, and operator-tooling artifacts.
+- **Key assumption:** Both external shoppers and internal operators materially shape the product scope.
+- **Missing decisions:** No persona-specific bootstrap decisions remain beyond the shared rollout questions tracked in `business-requirements.md` and `roadmap.md`.
+
+## Primary personas
+
+### 1. Outfit-seeking online shopper
+**Who they are:** A customer browsing suits, jackets, shirts, shoes, and accessories online who wants help assembling a complete look.
+
+**Goals**
+- Find items that work together without second-guessing color or formality.
+- Understand what completes the look from a starting product.
+- Buy with confidence in one session when possible.
+
+**Pain points**
+- Product pages answer "what is this item" better than "what should I wear with it."
+- Generic recommendations show alternatives instead of complements.
+- The customer must mentally combine color, fabric, season, and occasion across categories.
+
+**Behavior and decision context**
+- Often starts from one anchor item such as a suit or jacket.
+- Compares options quickly and may abandon if the full look remains unclear.
+- Uses context like event type, season, or destination even if it is not explicitly collected.
+
+**Success looks like**
+- A recommendation set quickly turns a single product view into a credible full outfit.
+- The shopper adds multiple compatible items with minimal uncertainty.
+
+### 2. Returning customer with style history
+**Who they are:** A known customer with previous purchases, browsing history, account behavior, and potential loyalty or email engagement signals.
+
+**Goals**
+- Receive recommendations that feel informed by prior purchases and personal taste.
+- Avoid duplicate or low-fit suggestions.
+- Discover new looks that extend the existing wardrobe.
+
+**Pain points**
+- Repeated exposure to items already owned or incompatible with prior purchases.
+- Lack of recognition of preferred fits, colors, fabrics, or price tier.
+- No clear bridge between purchase history and future outfit-building guidance.
+
+**Behavior and decision context**
+- Shops intermittently across seasons and occasions.
+- May respond to email, retargeting, or clienteling outreach rather than only onsite browsing.
+- Expects higher relevance than a first-time visitor.
+
+**Success looks like**
+- Recommendations reflect wardrobe continuity, not just session-level popularity.
+- The customer feels understood and returns for additional categories over time.
+
+### 3. Occasion-led shopper
+**Who they are:** A customer shopping for a specific moment such as a wedding, interview, business trip, or seasonal wardrobe refresh.
+
+**Goals**
+- Translate an occasion into a complete, appropriate outfit.
+- Balance dress code, climate, and personal style.
+- Move from inspiration to purchase quickly.
+
+**Pain points**
+- Occasion intent is not captured well by standard product recommendations.
+- It is difficult to judge whether a look is suitable for formal, business, travel, or seasonal needs.
+- Context such as city, weather, or time of year is rarely reflected in recommendations.
+
+**Behavior and decision context**
+- Starts with event intent or a specific climate-driven need.
+- May browse inspiration pages before landing on individual products.
+- Responds well to curated bundles or look narratives.
+
+**Success looks like**
+- The platform suggests a full outfit that fits the event and local context.
+- The customer does not need to stitch together advice from multiple places.
+
+## Secondary personas
+
+### 4. In-store stylist or clienteling associate
+**Goals**
+- Use platform recommendations as a strong starting point for assisted selling.
+- Adapt curated or personalized looks during appointments and store visits.
+- Understand why a recommendation set was generated at a practical level.
+
+**Pain points**
+- Styling guidance may be inconsistent between channels.
+- Manual look building is time-consuming and difficult to scale.
+- Customer context from ecommerce and store interactions may be fragmented.
+
+**Success looks like**
+- Faster preparation for appointments and better attachment selling in store.
+
+### 5. Merchandiser or campaign owner
+**Goals**
+- Curate looks, define compatibility or exclusion rules, and control campaign presentation.
+- Balance brand presentation, inventory realities, and AI-driven ranking.
+- Launch seasonal or occasion-focused recommendation strategies quickly.
+
+**Pain points**
+- Limited control over how recommendation logic expresses merchandising intent.
+- Manual curation does not scale across all surfaces and markets.
+- Difficult to measure which curated logic drives commercial impact.
+
+**Success looks like**
+- The team can adjust looks and rules without bespoke engineering changes for each campaign.
+
+### 6. Marketing, product, and analytics stakeholders
+**Goals**
+- Reuse recommendation intelligence in email, personalization, and optimization workflows.
+- Measure recommendation quality and downstream commercial impact.
+- Run experiments and compare performance across channels.
+
+**Pain points**
+- Fragmented data and inconsistent identifiers across channels.
+- Limited telemetry linking recommendation impressions to later outcomes.
+- Difficulty determining whether performance came from curation, rules, or AI ranking.
+
+**Success looks like**
+- Shared recommendation datasets, delivery APIs, and telemetry support confident optimization decisions.

--- a/docs/project/problem-statement.md
+++ b/docs/project/problem-statement.md
@@ -1,0 +1,55 @@
+# Problem Statement
+
+## Artifact metadata
+- **Upstream source:** GitHub issue #37 master product description.
+- **Bootstrap stage:** Bootstrap project documentation.
+- **Next downstream use:** Problem framing for later BR and feature-breakdown artifacts.
+- **Key assumption:** The central unsolved customer need is complete-outfit construction, not only product discovery.
+- **Missing decisions:** Shared rollout and identity questions are tracked in `business-requirements.md`, `roadmap.md`, and `architecture-overview.md`.
+
+## Current problem
+SuitSupply customers often know the first item they want to explore, but not the full outfit they should build around it. A shopper may land on a navy suit, linen jacket, or winter tailoring page and still have unanswered questions about the right shirt, tie, shoe, belt, outerwear, or accessory combination for the setting.
+
+Current ecommerce recommendation patterns are not enough for this behavior. Similar products, popularity lists, and frequently-bought-together modules do not reliably account for:
+- style compatibility across categories;
+- occasion and dress-code intent;
+- season, weather, and local market context;
+- differences between RTW and CM journeys;
+- the customer's past purchases and style profile;
+- merchandising priorities and curated looks.
+
+## Who experiences the problem
+### Customers
+- New shoppers who need inspiration and confidence to build a polished look.
+- Returning customers who expect recommendations to reflect prior purchases and preferences.
+- Occasion-led shoppers who care about the situation first, not the individual product first.
+
+### Internal teams
+- In-store stylists who want a stronger starting point for assisted selling.
+- Merchandisers who need structured control over looks and rule-based overrides.
+- Marketing teams that need relevant multi-item recommendations for outbound campaigns.
+- Product and analytics teams that need measurable recommendation behavior across channels.
+
+## Why current alternatives are insufficient
+Current alternatives optimize around co-occurrence or product similarity, not outfit construction. They tend to:
+- over-recommend near substitutes instead of complements;
+- ignore nuance in color, pattern, fabric, and formalwear compatibility;
+- treat channels independently instead of sharing intelligence across ecommerce, email, and clienteling;
+- provide limited operator control and limited feedback loops for learning.
+
+## Why now
+The business already has the styling knowledge and merchandising intent needed to create differentiated outfit recommendations. The missing piece is a consistent data-driven platform that can operationalize that knowledge across channels while learning from customer behavior.
+
+This is timely because:
+- customers expect more personalized digital shopping assistance;
+- SuitSupply already spans online and assisted-selling channels that can benefit from a shared intelligence layer;
+- the business has clear commercial upside in conversion, AOV, and retention;
+- AI ranking and graph-based recommendation approaches can now be blended with business rules at practical scale.
+
+## Consequences of not solving it
+If the problem remains unsolved:
+- customers continue to hesitate or purchase incomplete outfits;
+- recommendation surfaces stay generic and easier for competitors to match;
+- internal teams keep relying on fragmented manual workflows;
+- personalization performance in email and clienteling remains inconsistent;
+- product and analytics teams lack the telemetry needed to improve recommendation quality systematically.

--- a/docs/project/product-overview.md
+++ b/docs/project/product-overview.md
@@ -1,0 +1,93 @@
+# Product Overview
+
+## Artifact metadata
+- **Upstream source:** GitHub issue #37 master product description plus bootstrap vision, goals, and problem framing.
+- **Bootstrap stage:** Bootstrap project documentation.
+- **Next downstream use:** Capability-level BR fan-out and product-to-architecture decomposition.
+- **Key assumption:** A shared recommendation platform should serve multiple channels from common data and delivery services.
+- **Missing decisions:** First-slice scope and operating choices are tracked in `business-requirements.md` and `roadmap.md`.
+
+## What the product is
+The AI Outfit Intelligence Platform is a recommendation platform for SuitSupply that generates complete-look and context-aware recommendations across ecommerce, clienteling, and marketing channels. It combines curated looks, rule-based merchandising controls, and AI-ranked personalization to recommend outfits, cross-sell items, upsells, occasion-based looks, contextual suggestions, and style bundles.
+
+## Product boundaries
+
+### In scope at the platform level
+- Recommendation generation for RTW and CM use cases.
+- Ingestion of product, customer, and context signals needed for recommendation quality.
+- Recommendation delivery through APIs and channel-specific surfaces.
+- Merchandising tools and governance needed to curate, control, and evaluate recommendations.
+- Analytics, experimentation, and telemetry tied to recommendation outcomes.
+
+### Out of scope at the platform level
+- Replacing core commerce checkout, catalog, POS, email-delivery, or CMS systems.
+- Building a fully automated stylist with no merchandising or human override controls.
+- Solving unrelated lifecycle marketing, loyalty, or inventory-planning workflows beyond the recommendation use case.
+
+## Major user journeys
+1. **Anchor-item outfit completion**: A customer starts from a suit, jacket, or shirt and receives a complete compatible outfit.
+2. **Occasion-led discovery**: A customer starts from an occasion or style inspiration page and receives looks aligned to dress code, season, and location.
+3. **Returning-customer personalization**: A known customer receives recommendations informed by wardrobe history, browsing behavior, and style signals.
+4. **CM configuration guidance**: A customer configuring custom garments receives compatible style, fabric, and premium-option suggestions.
+5. **Assisted selling and outreach**: Stylists and marketers reuse recommendation intelligence for appointments, clienteling, and personalized email.
+
+## Recommendation types
+- Outfit recommendations
+- Cross-sell recommendations
+- Upsell recommendations
+- Curated style bundles
+- Occasion-based recommendations
+- Contextual recommendations
+- Personal recommendations based on profile and behavior
+
+## Primary surfaces and channels
+- Product detail pages
+- Cart
+- Homepage and web personalization surfaces
+- Style inspiration or look-builder pages
+- Email campaigns
+- In-store clienteling interfaces
+- Future mobile and API-driven experiences
+
+## Major workflows
+
+### 1. Product and signal ingestion
+The platform ingests catalog attributes, imagery, inventory, customer events, purchase history, and context signals such as location, season, and weather.
+
+### 2. Identity and profile formation
+Signals from ecommerce, CRM, loyalty, clienteling, and store activity are resolved into a customer profile or confidence-scored anonymous session profile.
+
+### 3. Look and relationship modeling
+Products, curated looks, outfit compatibility rules, and purchase affinities are modeled so the system can reason across categories rather than only within a category.
+
+### 4. Recommendation generation
+The engine blends curated look inputs, rule-based constraints, and AI ranking to produce recommendation sets appropriate for the current user, product, and context.
+
+### 5. Delivery and rendering
+A recommendation API returns channel-ready recommendation groups such as outfits, cross-sell, upsell, or style bundles to customer-facing and operator-facing surfaces.
+
+### 6. Measurement and optimization
+Impressions, clicks, saves, add-to-cart events, purchases, overrides, and experiment context are captured so teams can evaluate recommendation quality and improve it.
+
+## Major capability areas
+- Catalog and product metadata ingestion
+- Customer event ingestion and identity resolution
+- Customer profile and segmentation services
+- Intent and context detection
+- Product relationship graph and outfit graph
+- Merchandising rules and curated look management
+- Recommendation ranking and retrieval services
+- Recommendation delivery API
+- Channel widgets and surface integration
+- Experimentation and analytics
+- Admin and governance controls
+
+## RTW and CM differences
+- **RTW** centers on standard product compatibility, inventory-aware recommendations, and faster transaction-oriented outfit completion.
+- **CM** requires compatibility guidance for configured garments, style options, fabric combinations, premium details, and appointment-led selling contexts.
+
+## Operating model for recommendation sources
+Every recommendation set should be understandable as a blend of one or more sources:
+- **Curated**: merchant-authored looks or campaign logic;
+- **Rule-based**: compatibility, inventory, exclusion, or brand-control logic;
+- **AI-ranked**: machine-assisted scoring over eligible items or looks.

--- a/docs/project/review-rubrics.md
+++ b/docs/project/review-rubrics.md
@@ -1,0 +1,122 @@
+# Review Rubrics
+
+## Artifact metadata
+- **Upstream source:** Repository review rules and GitHub issue #37 bootstrap context.
+- **Bootstrap stage:** Bootstrap support documentation.
+- **Next downstream use:** Structured review passes for project docs, BRs, architecture, plans, build artifacts, and QA outputs.
+- **Key assumption:** Every later stage will use the same six-dimension scoring model unless the repository standards change explicitly.
+- **Missing decisions:** Stage-specific board policies may add detail later, but not new scoring dimensions or thresholds.
+
+## Purpose
+Define the common review model for artifacts created in this repository so every stage uses the same scoring dimensions, thresholds, confidence rules, and promotion logic.
+
+## Review dimensions
+Score every reviewed artifact from 1 to 5 in each dimension.
+
+| Dimension | What good looks like | Common failure mode |
+| --- | --- | --- |
+| Clarity | The artifact is easy to follow, uses repository terminology consistently, and makes scope and intent explicit. | Ambiguous scope, unclear terminology, or confusing structure. |
+| Completeness | All required sections, dependencies, constraints, and missing decisions for the stage are present. | Required sections or downstream-critical details are missing. |
+| Implementation Readiness | The next stage can start without guessing core behavior, interfaces, or acceptance criteria. | The next stage would need to infer major requirements or contracts. |
+| Consistency With Standards | The artifact follows repository standards for terminology, lifecycle states, traceability, and structure. | It conflicts with project standards or uses ad hoc naming or states. |
+| Correctness Of Dependencies | Upstream sources, downstream impacts, interfaces, and sequencing assumptions are accurate and explicit. | Missing or incorrect dependencies, unsupported assumptions, or broken traceability. |
+| Automation Safety | The artifact respects approval boundaries, trigger context, and deterministic validation needs. | It overclaims approval, completion, or certainty that the evidence does not support. |
+
+## Score anchors
+
+### 1 - Unusable
+- Major sections are missing or wrong.
+- The artifact cannot safely support downstream work.
+- Terminology, dependencies, or status handling is materially incorrect.
+
+### 2 - Weak
+- The artifact has some useful content but still contains blocking ambiguity, missing sections, or incorrect assumptions.
+- Downstream work would likely be delayed or mis-scoped.
+
+### 3 - Adequate
+- The artifact is understandable and mostly complete.
+- There are still meaningful gaps, but they are not all blocking.
+- Downstream work can begin only with caution and explicit follow-up.
+
+### 4 - Strong
+- The artifact is clear, materially complete for the stage, and aligned with repository standards.
+- Remaining gaps are minor, explicitly called out, and do not undermine the handoff.
+
+### 5 - Exemplary
+- The artifact is immediately actionable, internally consistent, thoroughly traceable, and clear about known unknowns.
+- It materially reduces downstream ambiguity and rework risk.
+
+## Thresholds and disposition
+Use the full score set, not only the average.
+
+| Condition | Disposition |
+| --- | --- |
+| Any dimension is 1 or 2 | `CHANGES_REQUESTED` |
+| Average is below 3.5 | `CHANGES_REQUESTED` |
+| Average is 3.5 or higher, but at least one dimension is 3 | Passing quality is possible, but only recommend promotion when the stage's approval mode allows it and no blocking issues remain. |
+| Average is above 4.1 and no dimension is below 4 | Eligible for promotion according to approval mode. |
+
+## Approval-mode handling
+Apply the stage or board item's recorded approval mode.
+
+| Approval mode | Promotion rule |
+| --- | --- |
+| `HUMAN_REQUIRED` | A passing review recommends `READY_FOR_HUMAN_APPROVAL`. A reviewer or human decision is still needed before `APPROVED`. |
+| `AUTO_APPROVE_ALLOWED` | A passing review may recommend `APPROVED` when thresholds are met and no milestone gate is bypassed. |
+
+## Confidence levels
+- `HIGH`: The reviewer has enough direct evidence from the artifact and linked standards to support the disposition.
+- `MEDIUM`: The artifact is mostly assessable, but some assumptions or gaps remain.
+- `LOW`: Critical context is missing, conflicting, or too ambiguous to assess responsibly.
+
+Low confidence should lead to `CHANGES_REQUESTED` or escalation when the main problem is unresolved product or governance decisions rather than document quality alone.
+
+## Blocking issues versus required edits
+- **Blocking issue:** Must be fixed before promotion because it changes scope, dependencies, readiness, or governance interpretation.
+- **Required edit:** Needed for a high-quality handoff but not necessarily a full blocker in isolation.
+- **Recommended edit:** Optional improvement that does not affect the disposition.
+
+## Stage-specific review focus
+
+### Bootstrap and project docs
+Stress product clarity, scope boundaries, terminology, roadmap logic, and whether later feature or architecture generation could proceed without guessing.
+
+### Business requirements and feature breakdowns
+Stress problem definition, user coverage, business value, scope boundaries, and measurable success criteria without drifting into technical design.
+
+### Architecture
+Stress system boundaries, contracts, dependency correctness, operational assumptions, and whether the implementation plan can be derived safely.
+
+### Implementation plans
+Stress workstream decomposition, sequencing, readiness gates, explicit interfaces, and acceptance criteria for downstream UI, backend, integration, and QA work.
+
+### Build artifacts
+Stress contract coverage, testability, observability, dependency correctness, and alignment with plan and architecture.
+
+### QA artifacts
+Stress scenario coverage, traceability to requirements, environment assumptions, and whether release or rollout decisions still require human or deterministic validation.
+
+## Escalation triggers
+Escalate instead of guessing when:
+- legal, privacy, or consent requirements are undefined for a data use case;
+- organization-owned dependencies or systems of record are unclear;
+- architecture trade-offs cannot be decided from existing project docs;
+- scope conflicts exist between upstream artifacts;
+- a human rejection implies upstream artifacts must be reworked.
+
+## Required review output shape
+Every structured review should include:
+1. artifact name and identifier if available;
+2. trigger source;
+3. disposition;
+4. scores for all six dimensions plus average;
+5. confidence and rationale;
+6. blocking issues;
+7. required edits;
+8. approval-mode interpretation;
+9. upstream artifacts to update if relevant;
+10. board update recommendation if a board exists;
+11. remaining human, CI, or merge requirements.
+
+## Notes for autonomous runs
+Autonomous runs may complete commit, push, and PR creation when the repository configuration allows it, but the artifact itself must still be explicit about any remaining human approval, CI, rollout, or merge dependencies.

--- a/docs/project/roadmap.md
+++ b/docs/project/roadmap.md
@@ -1,0 +1,153 @@
+# Roadmap
+
+## Artifact metadata
+- **Upstream source:** GitHub issue #37 master product description plus bootstrap project docs.
+- **Bootstrap stage:** Bootstrap project documentation.
+- **Next downstream use:** Capability-level BR fan-out, architecture sequencing, and implementation-plan gating.
+- **Key assumption:** The first live slice should validate RTW PDP outfit recommendations before broader channel and CM expansion.
+- **Approval note:** This roadmap sets directional phase order; later BR and architecture artifacts should refine phase content without contradicting the sequence unless the roadmap is updated.
+
+## Purpose
+Provide a phased delivery sequence for the AI Outfit Intelligence Platform that is practical for staged architecture, implementation, and rollout work.
+
+## Delivery principles
+- Build the data and control foundation before scaling customer-facing surfaces.
+- Deliver one dependable recommendation path before widening channel coverage.
+- Separate foundational platform capabilities from later optimization and expansion work.
+- Keep RTW breadth earlier than deep CM sophistication, while preserving CM in the platform design from the start.
+
+## Recommended phases
+
+### Phase 0 - Bootstrap and operating foundation
+**Theme:** Establish canonical project docs, operating model, review criteria, and initial roadmap.
+
+**Why first:** Later work needs a shared source of truth before feature decomposition starts.
+
+**Checkpoint:** `docs/project/` is complete enough to drive business-requirements and architecture fan-out.
+
+### Phase 1 - Data and recommendation foundation
+**Theme:** Create the minimum viable platform core.
+
+**Focus areas**
+- Catalog and inventory ingestion for RTW and CM attributes
+- Customer event ingestion and session tracking
+- Identity resolution approach and customer profile foundation
+- Product relationship graph and curated look model
+- Initial merchandising rule framework
+- Recommendation telemetry model and analytics basics
+
+**Dependencies**
+- Requires agreement on source systems, canonical identifiers, and privacy constraints.
+
+**Checkpoint**
+- The platform can assemble eligible complete-look candidates and record recommendation telemetry even before every channel consumes it.
+
+**First fan-out candidates**
+- BR-002: catalog, event, identity, and recommendation telemetry foundation
+- BR-003: product relationship graph, curated looks, and merchandising-rule controls
+
+### Phase 2 - Recommendation engine and delivery API
+**Theme:** Turn foundational data into usable recommendation services.
+
+**Focus areas**
+- Context engine inputs such as location, season, and weather
+- Recommendation retrieval, ranking, and rule orchestration
+- Recommendation delivery API contracts
+- Recommendation-set tracing, observability, and performance targets
+- Early experimentation hooks
+
+**Dependencies**
+- Depends on Phase 1 data quality, identity boundaries, and catalog normalization.
+
+**Checkpoint**
+- A stable API can return outfit, cross-sell, upsell, and style-bundle recommendation sets for controlled test cases.
+
+**First fan-out candidates**
+- BR-004: recommendation delivery API and trace contract
+- Architecture slice for ranking, rule orchestration, and context-engine composition
+
+### Phase 3 - Initial customer-facing rollout
+**Theme:** Launch the first high-impact customer surfaces and learn from real behavior.
+
+**Focus areas**
+- PDP complete-the-look or outfit recommendations
+- Cart cross-sell and upsell recommendations where scope allows
+- Style inspiration or look-builder experience if included in phase scope
+- Recommendation measurement dashboards and experiment readouts
+
+**Dependencies**
+- Depends on delivery API readiness, channel integration work, and telemetry validation.
+
+**Checkpoint**
+- At least one primary ecommerce surface is live with measurable recommendation outcomes.
+
+**First fan-out candidates**
+- BR-001: PDP RTW outfit recommendation experience
+- Follow-on cart or inspiration BR only after the PDP slice is explicitly approved
+
+### Phase 4 - Personalization and operator tooling
+**Theme:** Strengthen relevance and operational control.
+
+**Focus areas**
+- Returning-customer personalization and wardrobe-aware logic
+- Merchandising admin workflows for rules, bundles, and curation
+- Experimentation management and governance workflows
+- Clienteling and email activation using shared recommendation logic
+
+**Dependencies**
+- Depends on trustworthy telemetry, operator workflows, and identity confidence for known customers.
+
+**Checkpoint**
+- Teams can tune, test, and reuse recommendations beyond a single onsite surface.
+
+### Phase 5 - CM depth and contextual sophistication
+**Theme:** Expand platform intelligence into deeper CM and context-aware scenarios.
+
+**Focus areas**
+- CM configuration compatibility and premium-option guidance
+- More advanced occasion, climate, and locale-aware logic
+- Better cross-channel continuity across ecommerce, clienteling, and outreach
+- Optimization loops using accumulated recommendation outcomes
+
+**Dependencies**
+- Depends on earlier foundation and control layers; CM sophistication should not be an afterthought, but it should build on a stable platform.
+
+**Checkpoint**
+- The platform supports materially richer recommendation quality across both RTW and CM contexts.
+
+## Canonical fan-out order
+To keep downstream work consistent, later agents should use this order unless an updated artifact supersedes it:
+1. BR-002: catalog, event, identity, and recommendation telemetry foundation
+2. BR-003: product relationship graph, curated looks, and merchandising-rule controls
+3. BR-004: recommendation delivery API and trace contract
+4. BR-001: PDP RTW outfit recommendation experience
+5. Returning-customer personalization, clienteling, email, and operator-tooling BR artifacts
+6. CM-specific recommendation-depth artifacts
+
+## Earlier versus later guidance
+### Prioritize earlier
+- Canonical identifiers and event taxonomy
+- Core recommendation eligibility and tracing
+- PDP and other high-intent surfaces
+- Merchandising rule controls needed to keep early launches safe
+
+### Defer until later unless a phase-specific case justifies otherwise
+- Broad multi-market rollout
+- Full channel parity across every surface
+- Deep CM decision support beyond the first compatible combinations
+- Sophisticated optimization loops that depend on substantial production telemetry
+
+## Review and test checkpoints
+- Bootstrap doc review before feature or BR fan-out.
+- Data-model and identity review before personalization work expands.
+- API contract review before channel integrations multiply.
+- Surface-specific validation before new customer-facing launches.
+- QA and human rollout review before production expansion to new channels or markets.
+
+## Missing decisions
+
+| Missing decision | Why it matters | Temporary bootstrap direction | Proposed resolution stage | Recommended owner |
+| --- | --- | --- | --- | --- |
+| Exact first-release surface and geography combination | Determines rollout risk, telemetry baselines, and integration scope. | Default to one PDP-focused pilot rollout. | First downstream BR fan-out and rollout planning. | Product and ecommerce leadership. |
+| Whether merchandising admin tooling ships before or alongside the first live recommendations | Affects operational readiness and build sequencing. | Start with lightweight operator workflows, then mature the admin surface in Phase 4 unless safety needs force earlier tooling. | BR and implementation planning for merchandising controls. | Merchandising and product operations. |
+| Whether CM enters Phase 3 in a limited form or stays a Phase 5 expansion theme | Affects domain-model prioritization and early delivery complexity. | Preserve CM in the platform model now but plan deep CM execution later by default. | BR refinement before Phase 3 execution. | Product and CM business owners. |

--- a/docs/project/standards.md
+++ b/docs/project/standards.md
@@ -1,0 +1,85 @@
+# Standards
+
+## Artifact metadata
+- **Upstream source:** Repository rules and GitHub issue #37 master product description.
+- **Bootstrap stage:** Bootstrap project documentation.
+- **Next downstream use:** Shared authoring, review, and terminology guidance for every later artifact.
+- **Key assumption:** The repository will introduce boards and stage artifacts after bootstrap, so standards must be usable before code delivery begins.
+- **Missing decisions:** Board schemas and stage-specific artifact templates can be added later without changing these baseline standards.
+
+## Purpose
+Define cross-cutting standards for documents, delivery artifacts, terminology, traceability, and quality across the AI Outfit Intelligence Platform repository.
+
+## Naming and structure
+- Use lowercase kebab-case filenames for docs.
+- Treat `docs/project/` as the canonical product and workflow layer.
+- Keep stage artifacts separated by purpose: project docs, business requirements, architecture, implementation plans, build artifacts, and QA artifacts.
+- Prefer tables and explicit lists when they make downstream action easier.
+
+## Required terminology
+Use these terms consistently:
+- **look**: the modeled group of compatible items maintained by curation or rules.
+- **outfit**: the customer-facing complete-look recommendation concept.
+- **recommendation**: any ranked or selected suggestion output by the platform.
+- **style profile**: the customer preference and history context used for personalization.
+- **merchandising rule**: an operator-defined control that constrains or prioritizes recommendation behavior.
+- **RTW**: Ready-to-Wear products and flows.
+- **CM**: Custom Made products and flows.
+
+## Recommendation-source language
+When relevant, specify whether a recommendation is:
+- curated;
+- rule-based;
+- AI-ranked;
+- or a blend of the above.
+
+Do not describe the platform as a simple similarity engine when the requirement is complete-look and context-aware recommendation.
+
+## Lifecycle and review expectations
+Use the exact lifecycle states defined in `agent-operating-model.md`:
+- `TODO`
+- `IN_PROGRESS`
+- `NEEDS_REVIEW`
+- `IN_REVIEW`
+- `CHANGES_REQUESTED`
+- `READY_FOR_HUMAN_APPROVAL`
+- `APPROVED`
+- `DONE`
+
+Use `review-rubrics.md` for scoring and disposition. Do not invent alternative scoring systems or lifecycle labels.
+
+## Traceability expectations
+Every non-trivial artifact should record:
+- its upstream source or parent artifact;
+- the next intended downstream artifact or board stage;
+- assumptions;
+- missing decisions;
+- any milestone gate or approval-mode interpretation that affects downstream work.
+
+## Documentation standards
+- Write for downstream execution, not only for summary.
+- Separate confirmed scope from assumptions and open questions.
+- Record missing decisions explicitly rather than leaving ambiguity implicit.
+- Avoid hiding critical constraints in prose when a table or bullet list would be clearer.
+- Keep product and business artifacts free of unnecessary technical implementation detail, but concrete enough for architecture to start.
+
+## Quality standards
+- Recommendation outputs should be measurable through consistent telemetry.
+- Customer-facing experiences should avoid exposing sensitive profile reasoning.
+- Inventory, availability, and compatibility constraints should be treated as hard-quality requirements for live recommendations.
+- Operator controls should be auditable and role-appropriate.
+- New work should include a clear validation approach before it is considered complete.
+
+## API, data, UI, and integration assumptions
+- APIs should be contract-first and preserve recommendation tracing metadata.
+- Data models should use stable canonical identifiers and explicit source mappings.
+- UI surfaces should communicate loading, empty, fallback, and unavailable states clearly.
+- Integrations should define ownership, retries, timeouts, and failure handling explicitly.
+
+## Automation and approval safety
+- Automation may draft, review, and propose, but it must not overclaim approval or production completion without the configured evidence.
+- Human-required stages remain human-required unless the recorded approval path explicitly allows otherwise.
+- Autonomous runs may complete commit and push behavior, but artifacts must still state unresolved gates and dependencies honestly.
+
+## Missing-decision rule
+If a topic matters to product scope, governance, or downstream implementation and the source material does not settle it, record it as `Missing decision` in the artifact instead of guessing.

--- a/docs/project/ui-standards.md
+++ b/docs/project/ui-standards.md
@@ -1,0 +1,44 @@
+# UI Standards
+
+## Artifact metadata
+- **Upstream source:** GitHub issue #37 master product description plus bootstrap product and standards docs.
+- **Bootstrap stage:** Bootstrap project documentation.
+- **Next downstream use:** UI architecture, component planning, surface-specific BRs, and QA validation.
+- **Key assumption:** Recommendation surfaces must communicate outfit context without exposing sensitive internal reasoning.
+- **Missing decisions:** Final surface-specific interaction patterns should be resolved in later UI BR and design artifacts.
+
+## Purpose
+Define shared expectations for customer-facing and operator-facing interfaces that consume or manage recommendations.
+
+## Core UI principles
+- Present recommendations as outfit-building help, not as generic substitute-product lists when the use case is complete-look guidance.
+- Match the recommendation presentation to the surface intent, such as PDP outfit completion, cart attachment, inspiration browsing, or clienteling preparation.
+- Make relevance visible through styling context, category completeness, and occasion fit rather than through technical system language.
+
+## Customer-facing expectations
+- Recommendation modules should clearly show the role of each item in the outfit where useful.
+- Surfaces should handle loading, empty, fallback, and unavailable states without degrading the core shopping flow.
+- Inventory or availability issues should not surface broken or misleading outfit suggestions.
+- Customer-facing messaging should avoid exposing sensitive profile reasoning.
+
+## Operator-facing expectations
+- Merchandisers and stylists should be able to understand whether a recommendation set came from curated, rule-based, AI-ranked, or blended logic.
+- Rule and look-management interfaces should show impact, scope, and audit history for changes.
+- Experiment and override workflows should minimize accidental live-impact mistakes.
+
+## Accessibility and consistency
+- Meet standard accessibility expectations for keyboard navigation, screen-reader support, color contrast, and semantic structure.
+- Use shared UI patterns and components where repeated recommendation modules appear across channels.
+- Keep language and labeling consistent for recommendation types and action states.
+
+## State and feedback patterns
+Support explicit UI handling for:
+- loading and skeleton states;
+- empty or no-fit-result states;
+- fallback recommendation states;
+- error states when delivery fails;
+- save, dismiss, and add-to-cart feedback;
+- operator override confirmation and audit feedback.
+
+## Analytics expectations
+Every recommendation surface should capture telemetry for impression, click, save, add-to-cart, purchase, dismiss, and operator override where applicable. UI implementations must preserve recommendation-set and trace identifiers so analytics can measure real outcome quality.

--- a/docs/project/vision.md
+++ b/docs/project/vision.md
@@ -1,0 +1,50 @@
+# Vision
+
+## Artifact metadata
+- **Upstream source:** GitHub issue #37 master product description.
+- **Bootstrap stage:** Bootstrap project documentation.
+- **Next downstream use:** Product framing for later BR, roadmap, and architecture work.
+- **Key assumption:** SuitSupply wants a platform strategy, not a one-off widget for a single channel.
+- **Missing decisions:** Shared rollout and operating-model questions are tracked in `business-requirements.md` and `roadmap.md`.
+
+## Product vision
+Build an AI Outfit Intelligence Platform that helps SuitSupply customers assemble complete, context-appropriate looks across Ready-to-Wear (RTW) and Custom Made (CM) journeys instead of making isolated product decisions.
+
+## Why this product should exist
+SuitSupply already has strong styling knowledge, curated looks, and merchandising judgment, but that expertise is not yet activated consistently across ecommerce, clienteling, marketing, and future digital surfaces. Customers still face the hardest part of menswear shopping on their own: turning a single product interest into a complete outfit that fits occasion, climate, personal taste, and prior wardrobe context.
+
+The platform should convert SuitSupply's styling knowledge into a repeatable recommendation capability that is:
+- customer-aware rather than generic;
+- complete-look oriented rather than single-item oriented;
+- controllable by merchandising teams rather than opaque black-box ranking only;
+- usable across online, in-store, and outbound channels rather than isolated to one surface.
+
+## Long-term ambition
+Create a shared recommendation platform that becomes the intelligence layer behind every outfit suggestion SuitSupply makes, whether the customer is browsing online, preparing for a wedding, working with an in-store stylist, configuring a CM garment, or receiving a personalized email.
+
+In its mature state, the platform should:
+- understand product compatibility across categories, fabrics, colors, patterns, and fit;
+- blend curated looks, rule-based merchandising controls, and AI ranking;
+- adapt to season, weather, market, and occasion;
+- recognize customer preference and purchase history without exposing sensitive reasoning;
+- support experiment-driven optimization across channels.
+
+## Differentiators
+This product should differentiate SuitSupply by combining:
+- complete-outfit recommendation logic instead of simple item similarity;
+- deep product and styling compatibility across tailoring categories;
+- both RTW and CM recommendation depth;
+- merchandising control with AI personalization rather than replacing one with the other;
+- shared delivery across PDP, cart, homepage, email, and clienteling surfaces.
+
+## Intended impact
+If executed well, the platform should:
+- increase conversion by helping customers decide faster and with more confidence;
+- increase basket size by surfacing high-fit complements and upgrades;
+- improve repeat purchase behavior through more relevant style suggestions;
+- make SuitSupply feel more like a stylist-guided brand than a commodity catalog.
+
+## Market and user impact
+The platform targets shoppers who want help building polished outfits, returning customers who expect more relevant styling over time, and internal teams who need a dependable recommendation foundation for merchandising, personalization, and clienteling.
+
+The intended user impact is simple: less uncertainty, faster outfit construction, better inspiration, and more confidence that a recommended look is actually wearable for the customer's situation.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add the initial canonical `docs/project/` bootstrap documentation layer for the AI Outfit Intelligence Platform
- include the required product docs for vision, goals, problem framing, personas, overview, business requirements, roadmap, architecture overview, and standards
- add the directly required supporting docs that the repository prompts and rules reference so future staged delivery prompts have valid canonical inputs
- define a bounded recommended first delivery slice and canonical first BR fan-out ordering for downstream work

## Docs created
- `docs/project/vision.md`
- `docs/project/goals.md`
- `docs/project/problem-statement.md`
- `docs/project/personas.md`
- `docs/project/product-overview.md`
- `docs/project/business-requirements.md`
- `docs/project/roadmap.md`
- `docs/project/architecture-overview.md`
- `docs/project/standards.md`
- `docs/project/api-standards.md`
- `docs/project/data-standards.md`
- `docs/project/ui-standards.md`
- `docs/project/integration-standards.md`
- `docs/project/review-rubrics.md`
- `docs/project/agent-operating-model.md`
- `docs/project/new-project-bootstrap-to-phased-agent-delivery.md`
- `docs/project/new-project-bootstrap-implementation-spec.md`

## Key assumptions
- the first delivery slice should start with RTW PDP outfit recommendations before broader channel rollout
- a recommendation profile service can serve as the canonical recommendation-serving layer while upstream commerce, CRM, POS, and clienteling identities are mapped into it
- CM is preserved in the domain model from bootstrap, but deeper CM execution can follow after the initial RTW-first slice

## Open questions
- exact first-release market and rollout cohort
- timing and depth of early CM scope
- final merchandising operating model for curated looks, exclusions, and experiment management
- final provider choices for weather, holiday, or other context enrichment

## Validation
- completed a bootstrap review-loop pass against the repository prompts and rubrics
- refined the docs until they were coherent enough for downstream BR and architecture fan-out
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-02569530-a86d-457c-90c0-581338de6d63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-02569530-a86d-457c-90c0-581338de6d63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

