### PR TITLE
Bootstrap initial docs for AI Outfit Intelligence Platform

### DIFF
--- a/docs/project/api-standards.md
+++ b/docs/project/api-standards.md
@@ -1,0 +1,61 @@
+# API Standards
+
+## Purpose
+Define baseline API expectations for services that expose recommendation functionality or supporting controls.
+
+## Practical usage
+Use these standards when designing recommendation delivery endpoints, internal administration APIs, and event ingestion contracts.
+
+## API style guidance
+- Prefer resource-oriented HTTP APIs with JSON payloads for external and cross-team consumers.
+- Version externally consumed APIs explicitly, for example `/v1/recommendations`.
+- Keep recommendation responses stable even when ranking strategies change internally.
+- Separate read APIs for recommendation retrieval from write APIs for feedback, overrides, or administration.
+
+## Core contract expectations
+Recommendation responses should include, where relevant:
+- recommendation set ID
+- trace ID
+- request context summary
+- recommendation type
+- source provenance such as curated, rule-based, or AI-ranked
+- items with canonical product identifiers
+- optional explanation metadata for internal or controlled consumer use
+
+## Versioning approach
+- Use additive changes whenever possible.
+- Breaking changes require a new versioned endpoint or explicit migration path.
+- Channel consumers should not parse undocumented internal fields.
+
+## Error model
+Use a consistent error envelope with:
+- machine-readable code
+- human-readable message
+- trace ID
+- optional field-level details for validation errors
+
+Suggested error categories:
+- invalid_request
+- unauthorized
+- forbidden
+- not_found
+- conflict
+- dependency_unavailable
+- rate_limited
+- internal_error
+
+## Authentication expectations
+- Customer-facing surfaces should use channel-appropriate service authentication rather than exposing privileged internal credentials.
+- Internal administration APIs should require authenticated service or user identity with role-based authorization.
+- Sensitive endpoints should log actor identity and change intent.
+
+## Contract consistency rules
+- Use canonical IDs for products, customers, looks, campaigns, and experiments.
+- Use consistent naming for request fields such as `customerId`, `productId`, `context`, `location`, and `weather` when those concepts are represented.
+- Inventory and policy filtering should be reflected in returned results rather than delegated to the consumer.
+- Request schemas should support optional context fields without forcing every surface to send the same payload.
+
+## Reliability expectations
+- Timeouts and retry behavior must be documented per integration path.
+- Idempotency keys are required for any write endpoint that can be safely retried.
+- Latency-sensitive recommendation endpoints should expose cache-safe semantics where appropriate.

--- a/docs/project/architecture-overview.md
+++ b/docs/project/architecture-overview.md
@@ -1,0 +1,85 @@
+# Architecture Overview
+
+## Purpose
+Provide a product-level architecture view for the AI Outfit Intelligence Platform.
+
+## Practical usage
+Use this document to guide detailed architecture work, service decomposition, integration design, and implementation planning.
+
+## Source
+- GitHub issue #37: Master product spec: AI Outfit Intelligence Platform (SuitSupply Recommendation Engine)
+
+## High-level system view
+The platform should be structured as a shared recommendation system with clear separation between data ingestion, profile and graph intelligence, recommendation generation, delivery, and governance.
+
+```text
+Source systems and feeds
+  -> catalog ingestion
+  -> customer signal ingestion
+  -> context ingestion
+  -> identity resolution and profile service
+  -> product relationship and outfit graph
+  -> candidate generation and ranking
+  -> recommendation delivery API
+  -> channel consumers (web, email, clienteling, future APIs)
+  -> telemetry, analytics, experimentation, and governance loops
+```
+
+## Major subsystems
+| Subsystem | Responsibility |
+| --- | --- |
+| Catalog ingestion and normalization | Ingest product data, enrich attributes, and maintain RTW/CM-ready product representations. |
+| Customer signal ingestion | Collect orders, browsing, add-to-cart, search, engagement, and assisted-selling signals. |
+| Context ingestion | Resolve weather, season, location, holiday, and session context needed for ranking. |
+| Identity resolution and profile service | Map channel identities to canonical customer profiles with confidence and consent controls. |
+| Product relationship graph | Represent category relationships, compatibility, style tags, and curated look associations. |
+| Outfit graph or curated look model | Store complete-look compositions, merchandising curation, and rule-based outfit structures. |
+| Recommendation engine | Generate candidates from curated, rule-based, and AI-ranked strategies, then score and filter them. |
+| Context engine | Translate raw context signals into recommendation-useful constraints and boosts. |
+| Delivery API | Provide stable response contracts for recommendation consumers across surfaces. |
+| Merchandising and campaign controls | Manage curated looks, overrides, campaign priorities, and go-live controls. |
+| Telemetry and analytics | Record recommendation sets, outcome events, experiments, and operational metrics. |
+| Observability and governance | Support auditability, incident analysis, privacy controls, and operational health. |
+
+## Data flow overview
+1. Product, customer, and context data arrive from internal or external source systems.
+2. Ingestion pipelines normalize and validate the inputs against canonical schemas.
+3. Identity resolution links channel identifiers to customer profiles where permitted and possible.
+4. Product relationships, curated looks, and compatibility rules create candidate generation inputs.
+5. The recommendation engine builds candidate sets using curated, rule-based, and AI-ranked sources.
+6. Ranking and filtering apply context, profile, inventory, policy, and channel constraints.
+7. The delivery API returns recommendation sets with metadata such as recommendation set ID, source provenance, and trace ID.
+8. Consumers emit impression and outcome telemetry back into analytics and optimization loops.
+
+## External integrations
+Expected high-level integrations include:
+- Commerce systems such as Shopify and OMS for product, order, and inventory data.
+- POS and store systems for store visits, appointments, and assisted-selling context.
+- Marketing platforms for email activation and engagement feedback.
+- Analytics systems for event collection, experimentation, and reporting.
+- Weather or contextual data providers where internal data is insufficient.
+
+## Technical boundaries
+- The delivery API should remain surface-agnostic while allowing channel-specific request context.
+- Merchandising controls should influence recommendation behavior without requiring code deployments for normal changes.
+- Identity resolution and consent enforcement should be platform-level concerns, not reimplemented per channel.
+- Inventory filtering should happen before customer-facing delivery to avoid recommending unavailable items.
+- RTW and CM should share foundational services but allow separate compatibility logic and request inputs.
+
+## Operational assumptions
+- Near-real-time event ingestion is desirable for behavioral relevance, but not every source requires streaming if freshness targets can still be met.
+- Recommendation generation should have fallbacks that work when customer profile or weather data is unavailable.
+- Recommendation telemetry must be end-to-end traceable from request through downstream outcome events.
+- Internal administration interfaces may consume the same APIs plus additional governance endpoints.
+
+## Implementation-oriented constraints
+- Channel consumers need stable schemas and versioning because recommendation logic will evolve.
+- Recommendation responses must be explainable enough for debugging, governance, and experimentation, even if not all reasoning is shown customer-facing.
+- Source-system data quality gaps should be expected; normalization and validation cannot be deferred.
+- Latency-sensitive surfaces such as PDP and clienteling likely require precomputation, caching, or hybrid candidate generation patterns.
+
+## Missing architecture decisions
+- Missing decision: online versus batch generation mix for each surface.
+- Missing decision: canonical storage choices for product graph, look graph, and event telemetry.
+- Missing decision: whether recommendation ranking is a single service or a pipeline of specialized services.
+- Missing decision: which systems own experimentation assignment and campaign targeting.

--- a/docs/project/business-requirements.md
+++ b/docs/project/business-requirements.md
@@ -1,0 +1,126 @@
+# Business Requirements
+
+## Purpose
+Capture the business requirements, scope boundaries, assumptions, and open questions for the AI Outfit Intelligence Platform.
+
+## Practical usage
+Use this as the canonical source for later feature breakdown, architecture, and implementation planning. Downstream artifacts should trace back to these requirements.
+
+## Source
+- GitHub issue #37: Master product spec: AI Outfit Intelligence Platform (SuitSupply Recommendation Engine)
+
+## Product objective
+Build an AI Outfit Intelligence Platform for SuitSupply that supports RTW and CM recommendations, generates multiple recommendation types, and delivers governed recommendation sets across digital, assisted, and outbound channels.
+
+## Target users
+### Primary users
+- Online shoppers browsing suits, shirts, shoes, and accessories.
+- Returning customers with purchase history and style signals.
+- Occasion-driven customers shopping for weddings, business meetings, interviews, travel, and seasonal needs.
+
+### Secondary users
+- In-store stylists and clienteling teams.
+- Merchandisers curating looks, rules, and campaigns.
+- Marketing teams activating recommendation-based campaigns.
+- Product, analytics, and optimization teams improving performance.
+
+## Business value
+- Increase conversion rate.
+- Increase basket size and average order value.
+- Increase customer lifetime value.
+- Improve style inspiration and discovery.
+- Improve cross-channel recommendation relevance.
+- Preserve merchandising control while enabling AI-driven personalization.
+- Differentiate SuitSupply from simpler recommenders that rely only on similarity or co-purchase.
+
+## Scope boundaries
+### In scope
+- Recommendation generation for complete looks and related cross-category suggestions.
+- RTW and CM recommendation support.
+- Customer, context, and product signal ingestion needed for recommendation quality.
+- Recommendation delivery to PDP, cart, homepage/personalization, style inspiration pages, email, and clienteling surfaces.
+- Merchandising controls, campaign management hooks, experimentation, analytics, and governance.
+
+### Out of scope for this bootstrap definition
+- Detailed downstream issue generation or board seeding.
+- Final model-selection decisions or vendor lock-in choices.
+- Full UI design specs per consuming channel.
+- Broader commerce platform replacement beyond recommendation and related controls.
+
+## Business requirements
+| ID | Requirement |
+| --- | --- |
+| BR-001 | The platform must ingest and normalize product catalog data including category, fabric, color, pattern, fit, season, occasion, style tags, price tier, inventory, imagery, and RTW/CM attributes. |
+| BR-002 | The platform must ingest customer signals including orders, browsing, page views, product views, add-to-cart events, search behavior, email engagement, loyalty or account activity, store visits, appointments, stylist notes, and saved looks or wishlists where available. |
+| BR-003 | The platform must ingest context signals including location, country, weather, season, holiday or event calendar, and relevant device or session context. |
+| BR-004 | The platform must support identity resolution and a usable customer profile that can unify cross-channel signals with explicit confidence and governance. |
+| BR-005 | The platform must model product relationships, curated looks, compatibility rules, and outfit graph logic needed for complete-look recommendations. |
+| BR-006 | The platform must generate outfit, cross-sell, upsell, curated style bundle, occasion-based, contextual, and personal recommendations. |
+| BR-007 | The platform must support curated, rule-based, and AI-ranked recommendation paths, with fallback behavior when data is sparse. |
+| BR-008 | The platform must expose recommendation results through a shared delivery API that can serve multiple surfaces and response types. |
+| BR-009 | The platform must support channel delivery for PDP, cart, homepage/personalization, style inspiration pages, email campaigns, and in-store clienteling interfaces, with future API-driven surface support. |
+| BR-010 | The platform must provide merchandising controls for curated looks, rule overrides, campaign priorities, and operational governance. |
+| BR-011 | The platform must support experimentation, recommendation telemetry, analytics, and performance reporting across channels. |
+| BR-012 | The platform must include governance for privacy, consent, auditability, and safe use of customer data in regional contexts. |
+| BR-013 | The platform must support RTW-specific and CM-specific recommendation logic, including configured garment compatibility, color palettes, fabric combinations, and premium option guidance for CM. |
+| BR-014 | The platform must consider inventory and availability constraints before final recommendation delivery. |
+| BR-015 | The platform must preserve traceability for why a recommendation set was returned, including source type, rules applied, and experiment context where applicable. |
+
+## Major workflows
+### Workflow 1: PDP outfit completion
+Input: product context plus optional customer context. Output: a recommendation set containing compatible outfit items and supporting metadata.
+
+### Workflow 2: Cart expansion and upsell
+Input: current basket contents and customer profile. Output: missing outfit pieces, premium substitutions, and relevant add-ons.
+
+### Workflow 3: Occasion and context-based discovery
+Input: explicit or inferred occasion plus context signals such as location, weather, and season. Output: complete looks aligned to the use case.
+
+### Workflow 4: Personalized re-engagement
+Input: customer profile, channel context, and campaign rules. Output: recommendation sets suitable for email or homepage personalization.
+
+### Workflow 5: Clienteling assistance
+Input: known customer profile, appointment intent, or stylist context. Output: editable, explainable recommendation sets suitable for assisted selling.
+
+### Workflow 6: Merchandising governance
+Input: curated looks, rules, campaigns, and seasonal priorities. Output: governed recommendation behavior and overrideable ranking logic.
+
+## Success measures
+### Outcome measures
+- Conversion lift in the +5% to +10% target range.
+- Average order value lift in the +10% to +25% target range.
+- Increased recommendation-attributed basket completion and repeat engagement.
+
+### Platform measures
+- Recommendation coverage across targeted channels.
+- Recommendation impression-to-click, add-to-cart, purchase, and save rates.
+- Override rate and curated look usage by merchandisers.
+- Data freshness, API reliability, and telemetry completeness.
+
+## Constraints
+- Recommendations must respect privacy, consent, and regional policy requirements.
+- The platform must degrade gracefully when customer or context data is missing.
+- Inventory and availability must be considered before recommendations are exposed.
+- Customer-facing outputs must stay brand-aligned and compatible with merchandising priorities.
+- RTW and CM may share platform infrastructure but should not be forced into identical recommendation logic.
+
+## Assumptions
+- Required product and customer data can be accessed from Shopify, OMS, POS, marketing, and analytics systems or equivalent source systems.
+- Weather, season, and regional context can be sourced from internal or third-party providers.
+- At least an initial set of curated looks or business rules will be available from merchandising teams.
+- Consuming channels can integrate with a shared API instead of each channel owning separate recommendation logic.
+- Recommendation quality will improve iteratively as telemetry and profile coverage increase.
+
+## Missing decisions and open questions
+- Missing decision: what surfaces are in the first production release versus later phases.
+- Missing decision: which source systems are authoritative for customer identity, order history, and product inventory.
+- Missing decision: the acceptable latency budget by channel, especially for PDP and clienteling use cases.
+- Missing decision: how much of the recommendation explanation should be surfaced customer-facing versus internal only.
+- Missing decision: whether the first release should prioritize PDP, cart, email, clienteling, or a combination.
+- Missing decision: how CM configuration state will be represented and passed into recommendation requests.
+- Missing decision: what approval workflow merchandisers need before curated looks or rules go live.
+
+## Governance notes
+- Customer data usage must follow consent and regional compliance requirements.
+- Merchandising overrides should be auditable, reversible, and attributable to an actor or campaign.
+- Experimentation must not bypass inventory, policy, or brand guardrails.

--- a/docs/project/data-standards.md
+++ b/docs/project/data-standards.md
@@ -1,0 +1,76 @@
+# Data Standards
+
+## Purpose
+Define the data principles and event standards needed for a governed outfit intelligence platform.
+
+## Practical usage
+Use this document when shaping schemas, identity models, telemetry, and data quality controls.
+
+## Key data principles
+- Prefer canonical domain entities over channel-specific copies.
+- Preserve source-system mappings rather than overwriting them.
+- Record recommendation provenance and telemetry so outcomes are auditable.
+- Treat consent, privacy, and regional restrictions as data-model concerns, not only policy text.
+
+## Canonical identifiers and ownership
+The platform should maintain canonical IDs for at least:
+- product
+- customer
+- look
+- recommendation set
+- merchandising rule
+- campaign
+- experiment
+- event
+
+Each canonical record should preserve:
+- source system name
+- source system identifier
+- last-updated timestamp
+- ownership or stewardship responsibility
+- identity resolution confidence where applicable
+
+## Event and telemetry standards
+Recommendation telemetry should support these event types where applicable:
+- impression
+- click
+- save
+- add-to-cart
+- purchase
+- dismiss
+- override
+
+Each event should include, at minimum:
+- event ID
+- event timestamp
+- recommendation set ID
+- trace ID
+- surface or channel
+- recommendation type
+- product or look references involved
+- customer or session reference, if permitted
+- experiment or variant context, if present
+- source provenance such as curated, rule-based, or AI-ranked
+
+## Identity and profile expectations
+- Identity resolution must separate asserted identity from probabilistic matches.
+- Profile joins should preserve confidence, consent status, and source provenance.
+- Do not assume a single channel identifier is globally stable without mapping logic.
+- Customer-facing experiences should avoid exposing sensitive inferred profile attributes.
+
+## Data consistency rules
+- Product attributes used for compatibility must be normalized across source systems.
+- Inventory freshness expectations should be documented and monitored because stale availability undermines trust.
+- Recommendation set IDs should remain stable throughout downstream telemetry for a given response instance.
+- Event schemas should be validated at ingestion and reject or quarantine malformed payloads.
+
+## Privacy and governance expectations
+- Use only customer data permitted for the use case and geography.
+- Respect opt-out and consent signals for personalization and outbound use cases.
+- Limit access to stylist notes or other sensitive internal signals based on role and need.
+- Maintain auditable records for overrides, campaign activation, and experiment exposure.
+
+## Auditability expectations
+- Recommendation outputs must be reproducible enough to debug major incidents or quality regressions.
+- Rule changes, curated look changes, and identity merges should be logged with actor and timestamp metadata.
+- Data quality monitoring should cover completeness, freshness, schema conformity, and joinability.

--- a/docs/project/goals.md
+++ b/docs/project/goals.md
@@ -1,0 +1,65 @@
+# Goals
+
+## Purpose
+Define the desired business, user, and operational outcomes for the AI Outfit Intelligence Platform.
+
+## Practical usage
+Use these goals to evaluate roadmap priority, architecture trade-offs, and release readiness for downstream work.
+
+## Source
+- GitHub issue #37: Master product spec: AI Outfit Intelligence Platform (SuitSupply Recommendation Engine)
+
+## Business goals
+| Goal | Intent | Evidence of progress |
+| --- | --- | --- |
+| Increase conversion | Help customers move from product interest to outfit purchase decisions. | Lift in recommendation-assisted conversion and attach rate. |
+| Increase average order value | Recommend complementary items that complete the look. | Lift in basket size, units per transaction, and accessory attachment. |
+| Increase customer lifetime value | Make repeat interactions more relevant across visits and channels. | Higher repeat purchase rate and recommendation-attributed revenue. |
+| Improve channel performance | Reuse recommendation intelligence across ecommerce, email, and clienteling. | Adoption of shared recommendation APIs and measurable channel lift. |
+| Preserve brand and merchandising control | Keep recommendations aligned with SuitSupply styling standards and commercial priorities. | Override usage, reduced off-brand outputs, and governance auditability. |
+
+## User goals
+### Primary user goals
+- Understand how to assemble a complete outfit for a product, occasion, or season.
+- Receive recommendations that match personal style signals and prior purchases.
+- See recommendations that are relevant to the current context, including weather and location.
+- Move smoothly from inspiration to purchasable outfit combinations.
+
+### Secondary user goals
+- Stylists need recommendations that accelerate assisted selling without replacing judgment.
+- Merchandisers need control over curated looks, rules, and campaign priorities.
+- Marketing teams need recommendation sets that can be activated in email and personalization programs.
+- Product and analytics teams need telemetry that supports experimentation and optimization.
+
+## Operational goals
+- Establish reliable ingestion for catalog, customer, and context signals.
+- Maintain canonical identifiers and identity resolution across channels.
+- Expose recommendation results through a reusable delivery API.
+- Log recommendation impression and outcome telemetry with sufficient traceability for experimentation.
+- Support governance, fallback behavior, and observability for production use.
+
+## Success criteria
+### Outcome targets from the source issue
+- Conversion increase target: +5% to +10%.
+- Average order value increase target: +10% to +25%.
+- Stronger engagement and repeat purchase behavior.
+- Improved personalized email and clienteling performance.
+
+### Release-level success criteria
+- The platform can generate outfit, cross-sell, upsell, style bundle, occasion-based, contextual, and personal recommendations.
+- RTW and CM use cases are both represented in the recommendation model.
+- At least one customer-facing digital surface and one assisted or outbound surface can consume the shared API.
+- Merchandising teams can apply curated looks and business rules without code changes.
+- Recommendation telemetry is sufficient to attribute impressions, clicks, add-to-cart events, purchases, and overrides.
+
+## Non-goals
+- Replacing human stylists or merchandisers with fully autonomous AI.
+- Building a generic marketplace recommender disconnected from SuitSupply brand logic.
+- Solving warehouse planning, sourcing, or long-range assortment optimization in this bootstrap scope.
+- Creating every possible downstream channel integration in the first release.
+- Exposing opaque or sensitive customer-profile reasoning directly in customer-facing interfaces.
+
+## Guardrails
+- Personalization should improve relevance without violating consent, privacy, or regional data rules.
+- Recommendation quality should not depend on a single model family; curated and rule-based fallbacks are required.
+- Success should be measured by business and user outcomes, not only click-through rate.

--- a/docs/project/integration-standards.md
+++ b/docs/project/integration-standards.md
@@ -1,0 +1,41 @@
+# Integration Standards
+
+## Purpose
+Define the baseline standards for integrating the outfit intelligence platform with commerce, marketing, analytics, and context systems.
+
+## Practical usage
+Use this document when planning external system dependencies, ingestion pipelines, and runtime service-to-service integrations.
+
+## Integration principles
+- Prefer explicit contracts over implicit field sharing.
+- Treat source systems as bounded dependencies with documented ownership and failure modes.
+- Decouple recommendation delivery from any single upstream system whenever practical.
+- Preserve observability and idempotency across both batch and event-driven integration paths.
+
+## Authentication and secret handling
+- Use service-specific credentials with the minimum required scope.
+- Store secrets in managed secret systems rather than source control or static configuration files.
+- Rotate credentials according to platform policy and after suspected exposure.
+- Log authentication failures without leaking secret material.
+
+## Retry, timeout, and idempotency guidance
+- Document timeout budgets per integration based on surface sensitivity.
+- Retries should use bounded backoff and only be applied to retry-safe operations.
+- Event ingestion and write-side operations should be idempotent by event ID or idempotency key.
+- When an upstream dependency is degraded, prefer stale-safe fallbacks or partial recommendation behavior over total failure where business-safe.
+
+## Observability expectations
+- Every integration path should emit health, latency, error-rate, and freshness signals.
+- Request and event correlation should preserve trace IDs across system boundaries where feasible.
+- Data sync jobs should report completeness, lag, and failure reasons.
+
+## Dependency management expectations
+- Record authoritative source ownership for catalog, orders, inventory, profile, and campaign data.
+- Validate schema changes before rollout to avoid silent downstream breakage.
+- Keep a clear distinction between system-of-record data and derived recommendation state.
+- Integrations that affect customer-visible recommendations should have defined rollback or disable strategies.
+
+## Failure-handling standards
+- Inventory failures should fail closed for customer-facing outputs whenever availability cannot be trusted.
+- Context provider failures such as weather outages should trigger fallback logic rather than suppressing recommendations entirely.
+- Marketing or clienteling consumers should be able to detect stale or partial recommendation sets through explicit metadata.

--- a/docs/project/personas.md
+++ b/docs/project/personas.md
@@ -1,0 +1,70 @@
+# Personas
+
+## Purpose
+Define the key users and internal stakeholders whose needs shape the platform.
+
+## Practical usage
+Use these personas when deriving workflows, acceptance criteria, and channel priorities.
+
+## Source
+- GitHub issue #37: Master product spec: AI Outfit Intelligence Platform (SuitSupply Recommendation Engine)
+
+## Primary personas
+
+### Persona P1: Digital outfit shopper
+| Dimension | Details |
+| --- | --- |
+| Role | Customer browsing suits, jackets, shirts, shoes, and accessories online. |
+| Goals | Build a complete outfit, avoid style mistakes, and buy with confidence. |
+| Pain points | Knows the main item they want but not what matches it; generic related products create noise. |
+| Behaviors | Starts from a PDP, category page, or look inspiration page; compares a few options before committing. |
+| Decision-making context | Needs confidence quickly and expects a curated, brand-aligned answer. |
+| Success looks like | Can move from one anchor product to a cohesive purchasable outfit in one session. |
+
+### Persona P2: Returning style-profile customer
+| Dimension | Details |
+| --- | --- |
+| Role | Existing customer with prior purchases, browsing history, or loyalty/account signals. |
+| Goals | Receive recommendations that complement owned wardrobe items and match personal taste. |
+| Pain points | Repeats the same discovery work every visit; existing recommendations do not reflect prior purchases. |
+| Behaviors | Returns through direct traffic, email, or seasonal shopping moments. |
+| Decision-making context | Expects the brand to remember fit, color tendencies, occasion patterns, and prior ownership. |
+| Success looks like | Sees recommendations that feel incremental, personal, and relevant to their wardrobe. |
+
+### Persona P3: Occasion-driven shopper
+| Dimension | Details |
+| --- | --- |
+| Role | Customer shopping for a defined event such as a wedding, interview, business meeting, or travel need. |
+| Goals | Receive outfit guidance that matches the occasion and removes uncertainty. |
+| Pain points | Occasion needs are not explicit in standard product discovery; compatibility across categories is hard. |
+| Behaviors | Searches broadly, reads styling content, and often needs more hand-holding than routine shoppers. |
+| Decision-making context | Balances formality, climate, season, and budget while trying not to make a styling error. |
+| Success looks like | Finds a suitable complete look without needing external research or in-store help. |
+
+## Secondary personas
+
+### Persona S1: In-store stylist or clienteling associate
+- Goal: Start from strong look suggestions, then tailor them for the customer.
+- Pain points: Manual outfit assembly is time-consuming and not always connected to digital history.
+- Success: The clienteling interface exposes recommendations that are editable, explainable, and inventory-aware.
+
+### Persona S2: Merchandiser
+- Goal: Encode curated looks, compatibility rules, seasonality, and campaign priorities.
+- Pain points: Styling knowledge is hard to operationalize consistently across channels.
+- Success: Can author or override recommendation logic without engineering changes and can measure impact.
+
+### Persona S3: Marketing manager
+- Goal: Activate recommendation sets in email and personalization programs.
+- Pain points: Channel-specific one-off logic creates inconsistent targeting and weak reuse.
+- Success: Can pull governed recommendation sets into campaigns with clear attribution and segmentation.
+
+### Persona S4: Product, analytics, and optimization lead
+- Goal: Understand recommendation performance and improve it through experimentation.
+- Pain points: Insufficient telemetry, fragmented systems, and unclear source-of-truth metrics.
+- Success: Can trace recommendation performance by surface, audience, algorithm source, and outcome event.
+
+## Persona implications for the platform
+- Customer-facing recommendations must support both anchor-product flows and occasion-led flows.
+- Personalization should incorporate prior purchases and browsing, but never depend on those signals being present.
+- Internal users need editable controls, traceability, and measurement rather than a black-box engine.
+- Assisted-selling users need near-real-time recommendations with clear fallback behavior.

--- a/docs/project/problem-statement.md
+++ b/docs/project/problem-statement.md
@@ -1,0 +1,68 @@
+# Problem Statement
+
+## Purpose
+Describe the customer and business problem the AI Outfit Intelligence Platform must solve.
+
+## Practical usage
+Use this document to keep later requirements, architecture, and implementation work anchored to the real problem rather than generic recommendation features.
+
+## Source
+- GitHub issue #37: Master product spec: AI Outfit Intelligence Platform (SuitSupply Recommendation Engine)
+
+## Current problem
+SuitSupply customers often shop in a decision space where the real goal is a complete outfit, but the ecommerce experience is still largely organized around isolated products. A customer can identify a suit or jacket they like, yet still be uncertain about the right shirt, tie, shoes, belt, outerwear, or seasonal variations that complete the look.
+
+This gap is especially costly in formalwear and occasion-based shopping because compatibility matters. Customers are not only asking for similar products; they are asking what works together for style, occasion, climate, and personal preferences.
+
+## Who experiences the problem
+### Primary users
+- Online shoppers browsing formalwear, businesswear, and accessories.
+- Returning customers whose past purchases and preferences are not fully reflected in recommendations.
+- Occasion-driven shoppers who need complete guidance for weddings, interviews, business travel, or seasonal wardrobe updates.
+
+### Secondary users
+- In-store stylists who benefit from faster starting points when building looks.
+- Merchandisers who need scalable ways to encode styling logic, curated looks, and business rules.
+- Marketing teams that need personalized recommendation sets for outbound campaigns.
+- Product and analytics teams that need measurable recommendation performance across channels.
+
+## Why current alternatives are insufficient
+Current commerce recommendation patterns usually emphasize one or more of the following:
+- similar items
+- frequently bought together
+- popularity-based ranking
+- simple co-occurrence logic
+
+These alternatives are insufficient because they do not reliably account for:
+- style compatibility across categories
+- occasion-specific outfit construction
+- seasonality and weather
+- customer profile and prior purchases
+- differences between RTW and CM workflows
+- merchandising control and campaign intent
+- channel-specific needs across web, email, and clienteling
+
+## Why now
+- SuitSupply already has meaningful internal styling and merchandising knowledge that can be operationalized rather than left fragmented across teams.
+- The business value case is explicit: higher conversion, higher basket size, and stronger repeat behavior.
+- Customers increasingly expect personalized guidance rather than static product grids.
+- Multi-channel activation requires a platform approach rather than one-off recommendation widgets.
+- CM and RTW need a shared recommendation foundation before the product surface footprint expands further.
+
+## Consequences of not solving it
+- Customers will continue to abandon or narrow purchases because they lack confidence in how to complete a look.
+- Revenue opportunity from cross-category attachment and upsell will remain under-realized.
+- Merchandising expertise will stay difficult to scale across channels.
+- Channel teams will build fragmented recommendation logic, creating inconsistent customer experiences.
+- Future experimentation, personalization, and analytics will remain limited by weak telemetry and disconnected systems.
+
+## Representative problem scenarios
+| Scenario | Current gap | Desired future state |
+| --- | --- | --- |
+| Customer buys a navy suit | The site may show more suits rather than the shirt, tie, shoes, and belt that complete the outfit. | The platform returns a complete outfit recommendation with compatible accessories and rationale. |
+| Customer browses linen jackets in Italy during summer | Recommendations may ignore weather, season, and location context. | The platform prioritizes lightweight complementary items suited to warm-weather Italian summer use cases. |
+| Customer shops winter suiting in London | Static related products may miss coats, boots, and fabric weight. | The platform reflects cold-weather context and seasonal outfit composition. |
+| Returning customer has prior purchases | Recommendations may not account for owned items or existing style profile. | The platform personalizes the next-best additions to the wardrobe. |
+
+## Problem framing for downstream work
+The core problem is not "build a recommender." The core problem is "build a governed outfit intelligence capability that translates style expertise, customer context, and behavioral signals into complete-look recommendations across channels."

--- a/docs/project/product-overview.md
+++ b/docs/project/product-overview.md
@@ -1,0 +1,93 @@
+# Product Overview
+
+## Purpose
+Provide a practical description of what the AI Outfit Intelligence Platform is, how it is used, and what major capability areas it must contain.
+
+## Practical usage
+Use this document as the shared product map for feature decomposition, architecture elaboration, and delivery sequencing.
+
+## Source
+- GitHub issue #37: Master product spec: AI Outfit Intelligence Platform (SuitSupply Recommendation Engine)
+
+## What the product is
+The AI Outfit Intelligence Platform is a recommendation platform that generates complete-look and related style recommendations for SuitSupply across customer-facing and internal channels. It combines catalog intelligence, customer signals, context signals, curated looks, compatibility rules, and machine-assisted ranking to produce recommendation sets that are appropriate for the product, person, occasion, and surface.
+
+The platform is not only a ranking engine. It is a governed product system that includes ingestion, identity, recommendation generation, delivery APIs, merchandising controls, analytics, and experimentation.
+
+## Recommendation outputs supported
+- Outfit recommendations
+- Cross-sell recommendations
+- Upsell recommendations
+- Curated style bundles
+- Occasion-based recommendations
+- Contextual recommendations
+- Personal recommendations based on customer profile and behavior
+
+## Primary surfaces and channels
+| Surface | Primary user | Platform role |
+| --- | --- | --- |
+| Product detail page (PDP) | Shopper | Recommend the rest of the look around an anchor product. |
+| Cart | Shopper | Fill missing outfit pieces, premium substitutions, and relevant add-ons. |
+| Homepage / personalization modules | Shopper | Surface relevant looks and category pathways based on profile and context. |
+| Style inspiration / look builder pages | Shopper | Provide complete looks and guided exploration. |
+| Email campaigns | Returning customer | Deliver personalized or occasion-led recommendations outside the session. |
+| In-store clienteling interface | Stylist | Seed a consultation with editable complete-look recommendations. |
+| Future mobile/API consumers | Shopper or internal user | Reuse the same governed recommendation service. |
+
+## Major user journeys
+### Journey 1: Anchor-product look completion
+A shopper views a suit or jacket and receives a coordinated set of shirts, ties, shoes, belts, and accessories that complete the outfit.
+
+### Journey 2: Occasion-led discovery
+A shopper starts from an event or intent such as wedding guest attire, interview suiting, or summer travel and receives a curated complete look aligned with that context.
+
+### Journey 3: Personal wardrobe extension
+A returning customer receives recommendations that complement prior purchases and avoid repeating owned or irrelevant items.
+
+### Journey 4: Context-aware seasonal adjustment
+The platform shifts recommendations based on geography, weather, and seasonality, such as linen and loafers for summer or flannel and outerwear for winter.
+
+### Journey 5: Assisted selling and campaign activation
+Internal users consume the same recommendation intelligence in clienteling tools and outbound marketing channels.
+
+## Major workflows
+1. Ingest and normalize product, customer, and context data.
+2. Resolve identities and maintain usable customer profiles.
+3. Model product relationships, curated looks, and compatibility rules.
+4. Detect intent from anchor products, session signals, and occasion context.
+5. Generate recommendation candidates from curated, rule-based, and AI-ranked sources.
+6. Filter and rank candidates using inventory, price tier, policy, and channel constraints.
+7. Deliver recommendation sets through channel-ready APIs.
+8. Capture telemetry and outcomes for optimization, analytics, and governance.
+
+## Major capability areas
+- Product catalog ingestion and normalization
+- Customer signal ingestion and session/event tracking
+- Identity resolution and customer profile service
+- Product relationship graph and outfit graph
+- Compatibility rules and merchandising rules
+- Context engine for weather, season, location, and event signals
+- Recommendation engine and ranker
+- Recommendation delivery API and response orchestration
+- Merchandising rule builder and campaign controls
+- Experimentation, analytics, and recommendation insights
+- Governance, observability, and operational controls
+
+## Product boundaries
+### In scope at the platform level
+- Shared recommendation intelligence across multiple surfaces.
+- Both RTW and CM recommendation support.
+- Curated plus AI-assisted recommendation generation.
+- Governance, telemetry, and experimentation as first-class capabilities.
+
+### Out of scope for this bootstrap layer
+- Detailed feature-by-feature implementation plans.
+- Board seeding, issue fan-out, or downstream task generation.
+- Final UI designs for each channel.
+- Assortment planning, sourcing, or non-recommendation merchandising systems.
+
+## Working definitions
+- Look: the platform-level grouping of compatible items and recommendation logic.
+- Outfit: the customer-facing expression of a complete look.
+- Style profile: the customer representation built from purchases, browsing, preferences, and context signals.
+- Merchandising rule: a business-authored control that influences candidate inclusion, exclusion, ordering, or channel eligibility.

--- a/docs/project/roadmap.md
+++ b/docs/project/roadmap.md
@@ -1,0 +1,131 @@
+# Roadmap
+
+## Purpose
+Describe a phased delivery path for the AI Outfit Intelligence Platform without overcommitting to calendar estimates.
+
+## Practical usage
+Use this roadmap to sequence downstream feature work, architecture depth, and implementation planning. It is ordered by dependency and operational readiness, not by arbitrary timelines.
+
+## Source
+- GitHub issue #37: Master product spec: AI Outfit Intelligence Platform (SuitSupply Recommendation Engine)
+
+## Delivery strategy
+Start with the shared data and governance foundation, then ship a controlled recommendation MVP on the highest-value surfaces, then expand personalization, channel breadth, and CM depth. Each phase should leave behind reusable platform capability rather than one-off channel logic.
+
+## Recommended phases
+| Phase | Theme | Why it comes here | Exit checkpoint |
+| --- | --- | --- | --- |
+| Phase 1 | Data, identity, and catalog foundation | All recommendation quality depends on normalized product, customer, and context inputs. | Core data contracts, profile foundation, and event telemetry are defined and testable. |
+| Phase 2 | Governed RTW recommendation MVP | Establish business value quickly with curated plus rule-based recommendation delivery on priority surfaces. | A production-ready MVP serves at least one high-intent digital surface with fallback behavior and telemetry. |
+| Phase 3 | Personalization and multi-surface expansion | Once the base delivery loop is stable, add customer-aware ranking and additional channels. | Shared API supports multiple surfaces and recommendation source attribution. |
+| Phase 4 | CM and assisted-selling depth | CM and clienteling add richer configuration and workflow complexity after the shared foundation is proven. | RTW and CM recommendation logic coexist with channel-specific constraints handled explicitly. |
+| Phase 5 | Optimization and operating scale | After channel breadth exists, optimize with experimentation, analytics, and governance maturity. | Teams can run experiments, measure impact, and manage overrides safely at scale. |
+
+## Phase details
+### Phase 1: Data, identity, and catalog foundation
+Focus areas:
+- Normalize product catalog attributes for RTW and CM.
+- Ingest behavior, order, and context signals.
+- Define canonical identifiers and identity resolution patterns.
+- Establish recommendation telemetry, event contracts, and traceability.
+- Confirm integration boundaries with commerce, POS, marketing, and analytics systems.
+
+Dependencies:
+- Access to source systems and required fields.
+- Agreement on inventory freshness and identity strategy.
+
+Review checkpoints:
+- Data model review for catalog, customer, context, and recommendation events.
+- Architecture review of ingestion, identity, and storage boundaries.
+
+### Phase 2: Governed RTW recommendation MVP
+Focus areas:
+- Launch curated and rule-assisted complete-look recommendations for RTW.
+- Deliver shared API responses for the first priority surfaces.
+- Implement inventory-aware filtering and graceful fallbacks.
+- Enable core merchandising controls and override logging.
+- Capture end-to-end telemetry from recommendation impression through purchase.
+
+Recommended first-release surfaces:
+- PDP should be first because it has clear anchor-product context and immediate attach-rate value.
+- Cart is a strong second candidate because it naturally supports missing-piece and upsell recommendations.
+
+Dependencies:
+- Phase 1 data foundation.
+- Initial curated look or rule inventory from merchandising.
+
+Review checkpoints:
+- Functional review of recommendation quality on known anchor products.
+- Reliability review of API latency, fallback behavior, and telemetry completeness.
+
+### Phase 3: Personalization and multi-surface expansion
+Focus areas:
+- Add customer profile signals and intent detection to ranking.
+- Expand to homepage personalization and email recommendation sets.
+- Introduce experimentation and variant management.
+- Refine source balancing among curated, rule-based, and AI-ranked candidates.
+
+Dependencies:
+- Sufficient telemetry from Phase 2 to tune ranking and evaluate lift.
+- Agreed activation model for outbound and homepage surfaces.
+
+Review checkpoints:
+- Experiment design review and metric readiness review.
+- Cross-surface consistency review for recommendation provenance and analytics.
+
+### Phase 4: CM and assisted-selling depth
+Focus areas:
+- Add CM-specific compatibility logic for fabrics, shirt styles, tie styles, color palettes, and premium options.
+- Support configured-garment inputs in recommendation requests.
+- Extend recommendations into clienteling and appointment workflows.
+- Account for longer consideration cycles and assisted-selling edits.
+
+Dependencies:
+- Stable delivery API and traceable profile model.
+- Clear representation of CM configuration state.
+
+Review checkpoints:
+- Domain review of RTW versus CM rule separation.
+- Assisted-selling workflow review for editability, trust, and usability.
+
+### Phase 5: Optimization and operating scale
+Focus areas:
+- Mature experimentation, analytics, governance, and campaign management.
+- Improve model-assisted ranking using accumulated telemetry.
+- Expand surface support for future mobile or partner API consumers.
+- Harden observability, audit trails, and operational playbooks.
+
+Dependencies:
+- Broad enough traffic and telemetry to support optimization.
+- Team operating model for experimentation and governance.
+
+Review checkpoints:
+- Experiment governance review.
+- Operational readiness review for scaling and incident handling.
+
+## Earlier vs later decisions
+### Decide earlier
+- Canonical identifiers and source-of-truth ownership.
+- First-release surfaces and latency budgets.
+- Recommendation telemetry schema and attribution model.
+- Governance rules for curated looks, overrides, and privacy.
+
+### Decide later, after platform basics work
+- Advanced model strategy and ranking sophistication.
+- Full channel rollout order after MVP evidence exists.
+- Fine-grained explanation patterns for each surface.
+- Broader automation around campaign management.
+
+## Phase dependencies summary
+- Phase 2 depends on Phase 1 because recommendation quality and traceability require normalized inputs.
+- Phase 3 depends on Phase 2 because personalization should build on real channel telemetry and working APIs.
+- Phase 4 depends on Phases 1 through 3 because CM and clienteling rely on shared identity, delivery, and governance capabilities.
+- Phase 5 depends on earlier phases because optimization only matters once governed production behavior exists.
+
+## Stop or continue criteria
+Continue to the next phase only when the current phase demonstrates:
+- clear input contracts
+- working fallback behavior
+- recommendation telemetry completeness
+- operational ownership and governance
+- evidence that the next phase will build on reusable platform capability rather than patching unresolved basics

--- a/docs/project/standards.md
+++ b/docs/project/standards.md
@@ -1,0 +1,75 @@
+# Standards
+
+## Purpose
+Define the cross-cutting standards that all downstream project artifacts and implementations should follow.
+
+## Practical usage
+Use this document as the baseline for naming, traceability, quality, review readiness, and cross-domain consistency across the project.
+
+## Source
+- GitHub issue #37: Master product spec: AI Outfit Intelligence Platform (SuitSupply Recommendation Engine)
+
+## Domain terminology standards
+Use the following terms consistently:
+- Look: the platform-level grouping of compatible items and recommendation logic.
+- Outfit: the customer-facing complete-look expression.
+- Style profile: the customer representation derived from behavior, purchases, preferences, and context.
+- Recommendation: a governed output that may be an outfit, cross-sell, upsell, style bundle, contextual, occasion-based, or personal suggestion.
+- Merchandising rule: a business-authored control over inclusion, exclusion, ordering, or channel eligibility.
+- RTW: Ready-to-Wear product and recommendation flows.
+- CM: Custom Made product and recommendation flows.
+
+## Documentation standards
+- `docs/project/` is the canonical source-of-truth layer for product and delivery context.
+- Documents must be concrete and implementation-oriented, not high-level marketing summaries.
+- Every downstream artifact should identify its source inputs and trace back to the relevant project documents.
+- Unknowns must be recorded explicitly as missing decisions rather than hidden in ambiguous language.
+- File names should be lowercase with hyphens.
+
+## Traceability standards
+- Requirements, architecture, implementation plans, and reviews should preserve identifiers and source references.
+- Recommendation outputs should be traceable to a recommendation set ID and trace ID.
+- Business rules, curated looks, campaign overrides, and experiments should be attributable to an actor or system process.
+- Cross-channel customer identity mappings should preserve source identifiers and confidence metadata.
+
+## Quality standards
+- Favor complete-look compatibility over simplistic item similarity.
+- Support curated, rule-based, and AI-ranked recommendation sources with explicit precedence and fallback behavior.
+- Never expose unavailable inventory on customer-facing surfaces.
+- Ensure telemetry covers impression, click, save, add-to-cart, purchase, dismiss, and override events where the surface supports them.
+- Preserve brand alignment and merchandising governance in all customer-visible recommendation experiences.
+
+## Delivery and lifecycle standards
+When boards and stage artifacts are created later, use the lifecycle states exactly as follows:
+- TODO
+- IN_PROGRESS
+- NEEDS_REVIEW
+- IN_REVIEW
+- CHANGES_REQUESTED
+- READY_FOR_HUMAN_APPROVAL
+- APPROVED
+- DONE
+
+Additional delivery expectations:
+- Do not skip review or dependency checks when promoting work between stages.
+- Approval mode should be explicit when later boards are seeded.
+- Downstream work should prefer narrow, auditable changes over broad speculative rewrites.
+
+## API, data, UI, and integration assumptions
+- APIs should be versioned, stable, and contract-oriented.
+- Data contracts should use canonical IDs, schema validation, and explicit ownership boundaries.
+- UI surfaces should use consistent empty, loading, fallback, and recommendation-explanation patterns.
+- Integrations should define timeout, retry, idempotency, authentication, and observability behavior up front.
+
+## Governance standards
+- Respect customer consent and regional data policy requirements.
+- Do not expose sensitive profile reasoning in customer-facing copy.
+- Ensure merchandising overrides and experiment changes are auditable.
+- Preserve a safe fallback path when personalization inputs are missing or degraded.
+
+## Review-readiness standards
+A downstream artifact is only ready for promotion when it is:
+- clear enough for another agent or team to act on without guessing
+- complete enough to avoid hidden dependencies
+- explicit about assumptions and missing decisions
+- consistent with the project vocabulary and scope boundaries

--- a/docs/project/ui-standards.md
+++ b/docs/project/ui-standards.md
@@ -1,0 +1,46 @@
+# UI Standards
+
+## Purpose
+Define cross-surface interface expectations for recommendation modules and internal control surfaces.
+
+## Practical usage
+Use these standards when designing customer-facing widgets, look-builder experiences, and internal merchandising or clienteling interfaces.
+
+## UI consistency principles
+- Recommendation modules should present complete-look intent clearly, not as a generic related-items carousel.
+- Surfaces should distinguish recommendation types when it helps user understanding, such as outfit versus upsell.
+- Customer-facing interfaces should keep copy simple and brand-aligned; internal interfaces may expose richer provenance and debugging details.
+- RTW and CM interfaces may differ in interaction depth, but should reuse shared terminology where possible.
+
+## Accessibility expectations
+- Recommendation components must support keyboard navigation, screen-reader labeling, and sufficient contrast.
+- State changes such as loading, saved, error, or add-to-cart feedback must be perceivable to assistive technologies.
+- Important outfit-composition information should not be conveyed only through imagery or color.
+
+## State and feedback patterns
+Every consuming surface should define:
+- loading state behavior
+- empty state behavior
+- fallback state behavior when personalization is unavailable
+- error handling behavior when recommendations cannot be loaded
+- inventory or availability feedback behavior
+
+Recommended behavior:
+- Fall back to curated or rule-based recommendations when personalization inputs are missing.
+- Avoid empty modules on high-value surfaces unless policy requires suppression.
+- Make unavailable or low-confidence items non-actionable or remove them before display.
+
+## Recommendation explanation patterns
+- Customer-facing rationale should be concise and non-sensitive, for example season, occasion, or "pairs well with" language.
+- Internal surfaces may expose richer explanation data such as source type, applied rule, and confidence or eligibility notes.
+- Do not expose sensitive profile reasoning or internal-only signals directly to customers.
+
+## Shared component expectations
+- Recommendation cards should reuse common product identity, pricing, availability, and imagery patterns.
+- Complete-look modules should make outfit composition visually understandable and easy to act on.
+- Internal editing tools should support preview, override, and audit-friendly change workflows.
+
+## Analytics and telemetry expectations
+- UI events must preserve recommendation set ID and trace ID.
+- Impression measurement rules should be explicit per surface to avoid inconsistent reporting.
+- User interactions such as click, save, dismiss, and add-to-cart should map to the shared telemetry model.

--- a/docs/project/vision.md
+++ b/docs/project/vision.md
@@ -1,0 +1,51 @@
+# Vision
+
+## Purpose
+Define why the AI Outfit Intelligence Platform exists and what long-term product outcome it should create.
+
+## Practical usage
+Use this document as the top-level product direction for later feature breakdowns, architecture planning, and prioritization decisions.
+
+## Source
+- GitHub issue #37: Master product spec: AI Outfit Intelligence Platform (SuitSupply Recommendation Engine)
+
+## Product vision
+Build SuitSupply's central recommendation platform for complete-look discovery so customers can confidently assemble outfits, not just buy isolated products. The platform should combine merchandising expertise, customer behavior, product compatibility, and live context to deliver recommendations that feel stylist-informed, commercially effective, and consistent across digital and assisted channels.
+
+## Long-term ambition
+The long-term product ambition is to make outfit intelligence a shared platform capability used by ecommerce, email marketing, in-store clienteling, merchandising, and future mobile or API-driven experiences. Over time, recommendation quality should improve from curated and rule-assisted suggestions to highly personalized, context-aware ranking that still preserves business control and brand standards.
+
+## Why this product should exist
+Current recommendation patterns in commerce usually optimize for similar items, co-purchase, or popularity. That approach does not solve the real customer question for formalwear and elevated apparel: "what completes this look for me, here, now, and for this occasion?" SuitSupply already has strong styling knowledge, but it is not consistently activated as a scalable product capability. This platform exists to turn that knowledge into an operational system that increases confidence, basket size, and repeat engagement.
+
+## Differentiators
+- Complete-look recommendations instead of single-item similarity only.
+- Joint use of curated, rule-based, and AI-ranked recommendation sources.
+- Support for both RTW and CM recommendation logic.
+- Context-aware ranking using location, season, weather, occasion, and session signals.
+- Cross-channel delivery for ecommerce, email, clienteling, and future surfaces.
+- Explicit merchandising governance, override controls, and experiment support.
+
+## Intended market and user impact
+### Customer impact
+- Reduce friction when building an outfit across suits, shirts, shoes, and accessories.
+- Improve confidence for occasion-based and seasonal shopping.
+- Make personalization feel relevant without losing brand coherence.
+
+### Business impact
+- Improve conversion by surfacing recommendations that complete the purchase decision.
+- Increase average order value through intelligent cross-sell and style bundle recommendations.
+- Improve customer lifetime value by making recommendations more useful across repeat visits and channels.
+- Differentiate SuitSupply from retailers that only provide simplistic related-product modules.
+
+### Internal team impact
+- Give merchandisers a system for curating and governing looks at scale.
+- Give stylists and clienteling teams better assisted-selling recommendations.
+- Give marketing and analytics teams a reusable recommendation platform with measurable outcomes.
+
+## Product principles
+- Recommendations must optimize for style compatibility, not only statistical co-occurrence.
+- Personalization must remain governable by merchandising and policy controls.
+- RTW and CM experiences should share a platform foundation but allow different recommendation logic where needed.
+- Channel consumers should receive recommendations through stable APIs and traceable telemetry.
+- Missing context should degrade gracefully to curated or rules-backed recommendations rather than empty states.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- create the initial `docs/project/` canonical documentation layer for the AI Outfit Intelligence Platform
- add core product docs covering vision, goals, problem statement, personas, product overview, business requirements, roadmap, architecture overview, and standards
- add supporting API, data, UI, and integration standards because the platform clearly depends on all four domains

## Docs created
- `docs/project/vision.md`
- `docs/project/goals.md`
- `docs/project/problem-statement.md`
- `docs/project/personas.md`
- `docs/project/product-overview.md`
- `docs/project/business-requirements.md`
- `docs/project/roadmap.md`
- `docs/project/architecture-overview.md`
- `docs/project/standards.md`
- `docs/project/api-standards.md`
- `docs/project/data-standards.md`
- `docs/project/ui-standards.md`
- `docs/project/integration-standards.md`

## Assumptions and open questions
- first-release surface prioritization is still open, though the roadmap recommends PDP first and cart second
- authoritative source systems for identity, orders, inventory, and CM configuration state are still undecided
- latency budgets, recommendation explanation depth, and merchandising approval workflow still need product and platform decisions
- referenced supporting guidance files under `docs/project/` were not present in the repository, so the bootstrap set records missing decisions directly in the new docs

## Validation
- docs-only change
- verified the full `docs/project/` file set exists on the branch and the branch is pushed cleanly
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0a23148c-fb37-4d51-b1a9-b65ecd92d528"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0a23148c-fb37-4d51-b1a9-b65ecd92d528"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

