### PR TITLE
docs: bootstrap outfit intelligence project docs

### DIFF
--- a/docs/project/api-standards.md
+++ b/docs/project/api-standards.md
@@ -1,0 +1,105 @@
+# API Standards
+
+## Purpose
+
+Define cross-cutting API standards for recommendation delivery and related service contracts in the AI Outfit Intelligence Platform.
+
+## Practical usage
+
+Use this document when designing recommendation-serving endpoints, telemetry ingestion APIs, admin APIs, and integration contracts consumed by channel teams.
+
+## API style guidance
+
+- Prefer resource-oriented HTTP APIs with JSON request and response bodies.
+- Use noun-based endpoint paths and explicit action semantics only where resource modeling would be misleading.
+- Keep recommendation APIs channel-agnostic; channel-specific presentation concerns belong outside the service contract.
+- Use structured nested objects for context, customer identity, and recommendation metadata rather than proliferating flat ad hoc parameters.
+
+## Recommended contract shape
+
+### Recommendation request pattern
+
+The recommendation delivery API should support inputs such as:
+- `customerId`
+- `sessionId`
+- `productId`
+- `context`
+- `location`
+- `weather`
+- `surface`
+- `mode` (`RTW` or `CM`)
+
+### Recommendation response pattern
+
+Responses should be able to return:
+- one or more recommendation groups by type
+- item-level metadata needed for rendering
+- recommendation set identifiers
+- trace identifiers
+- experiment or variant metadata when applicable
+- rule or reason metadata suitable for analytics and support
+
+## Versioning approach
+
+- Version public or broadly consumed APIs in the path, for example `/v1/recommendations`.
+- Prefer additive changes within a version.
+- Breaking changes require a new version and a migration plan for consumers.
+- Contract examples in docs should indicate versioned paths explicitly.
+
+## Authentication expectations
+
+- Use service-to-service authentication for internal channel consumers and integration clients.
+- Do not place secrets in client-rendered code or URL query strings.
+- Auth context should support scoping by consumer application and environment.
+- Customer identity in a request does not replace service authentication; both concerns should be handled distinctly.
+
+## Error model
+
+Use a machine-readable error envelope with consistent fields.
+
+| Field | Purpose |
+| --- | --- |
+| `code` | Stable programmatic error code. |
+| `message` | Human-readable summary. |
+| `traceId` | Identifier for diagnostics and support. |
+| `details` | Optional structured error details. |
+| `retryable` | Whether the caller may retry safely. |
+
+### Error handling rules
+
+- Use consistent error codes across endpoints.
+- Differentiate validation failures, upstream dependency failures, authorization failures, and internal service failures.
+- When possible, return partial or fallback recommendation behavior rather than hard failure on optional context dependencies.
+- Never expose sensitive internal reasoning or secrets in error payloads.
+
+## Contract consistency rules
+
+- Recommendation types should use stable enum values across request and response contracts.
+- Surface names, mode names, and item identifiers must match project standards.
+- Context objects should preserve canonical field names for location, weather, season, and occasion.
+- Response collections should have deterministic ordering semantics when ranking is meaningful.
+- Unknown optional fields should be ignored by consumers unless the contract states otherwise.
+
+## Idempotency and retries
+
+- `GET` endpoints must be safe to retry.
+- Event or feedback ingestion endpoints that accept recommendation outcome events should support idempotency keys or equivalent duplicate protection.
+- Callers should treat retryability as a contract concern, not a guess based on status code alone.
+
+## Observability and tracing
+
+- Every request should carry or generate a `traceId`.
+- Recommendation responses should include a `recommendationSetId` that downstream events can reference.
+- Logs, metrics, and events should allow joining request context, recommendation outputs, and business outcomes.
+
+## Example endpoint direction
+
+These are directionally appropriate examples, not final endpoint commitments:
+- `GET /v1/recommendations`
+- `POST /v1/recommendation-events`
+- `POST /v1/merchandising-rules`
+
+## Missing decisions
+
+- Missing decision: whether recommendation delivery should be a synchronous read API only or also support precomputed batch export contracts.
+- Missing decision: whether clienteling and email consumers need separate contract variants or a single shared response schema with surface metadata.

--- a/docs/project/architecture-overview.md
+++ b/docs/project/architecture-overview.md
@@ -1,0 +1,144 @@
+# Architecture Overview
+
+## Purpose
+
+Provide a product-level technical view of the AI Outfit Intelligence Platform: the major subsystems, how data moves through them, where integrations sit, and which boundaries matter for later design work.
+
+## Practical usage
+
+Use this document to:
+- orient later architecture and implementation planning
+- show how shopper-facing recommendations depend on shared platform services
+- make subsystem boundaries and assumptions explicit before detailed design begins
+
+## High-level system view
+
+The platform should be designed as a shared recommendation intelligence layer between upstream source systems and downstream consumer channels.
+
+```text
+Upstream systems
+  -> product and inventory feeds
+  -> orders and customer records
+  -> browsing, search, and engagement events
+  -> POS, appointments, stylist notes
+  -> weather, season, holiday, and event sources
+
+Ingestion and foundation layer
+  -> product normalization
+  -> event pipeline and session tracking
+  -> identity resolution
+  -> customer profile service
+  -> curated look and rule ingestion
+
+Decisioning layer
+  -> product relationship graph
+  -> look compatibility and outfit assembly model
+  -> context engine
+  -> candidate generation
+  -> ranking and rule application
+
+Delivery and control layer
+  -> recommendation delivery API
+  -> merchandising and admin controls
+  -> experiment allocation
+  -> traceability and diagnostics
+
+Consumer channels
+  -> ecommerce surfaces
+  -> email and CRM
+  -> in-store clienteling
+  -> future mobile or partner consumers
+
+Feedback loop
+  -> recommendation telemetry
+  -> analytics and insights
+  -> model or rule optimization
+```
+
+## Major subsystems
+
+| Subsystem | Responsibility |
+| --- | --- |
+| Product catalog ingestion | Normalize product attributes, images, inventory, seasonality, and RTW or CM metadata from source systems. |
+| Customer signal ingestion | Capture orders, views, add-to-cart actions, search, email engagement, store visits, and other behavioral signals. |
+| Event pipeline and session tracking | Create a consistent event stream that supports anonymous and known journeys. |
+| Identity resolution and profile service | Link channel identifiers, build a usable style profile, and expose profile features to recommendation logic. |
+| Look and merchandising model | Store curated looks, merchandising rules, campaign controls, exclusions, and override logic. |
+| Product relationship and look graph | Represent compatibility between products, categories, styles, and look structures. |
+| Context engine | Convert location, weather, season, holiday, and occasion inputs into recommendation features. |
+| Recommendation engine | Generate candidates, apply business rules, rank outputs, and assemble recommendation sets. |
+| Recommendation delivery API | Serve recommendations to channels with a stable contract and metadata for rendering, telemetry, and experiments. |
+| Analytics and experimentation layer | Measure outcome events, support testing, and provide insight into recommendation performance. |
+| Governance and admin interfaces | Support rule ownership, approvals, observability, auditability, and operational controls. |
+
+## Data flow overview
+
+1. Upstream systems provide product, inventory, customer, and event data.
+2. Ingestion services normalize source-system differences into canonical platform entities.
+3. Identity services connect anonymous sessions, known customers, and channel-specific identifiers where possible.
+4. Profile and context services produce recommendation features from behavioral and environmental signals.
+5. Look, graph, and rule services provide candidate relationships and business constraints.
+6. Recommendation engine assembles and ranks recommendation candidates for the request context.
+7. Delivery API returns recommendation sets, metadata, and trace identifiers to consuming channels.
+8. Channels emit outcome events that feed analytics, experimentation, and later optimization.
+
+## External integrations at a high level
+
+| Integration category | Purpose |
+| --- | --- |
+| Commerce and OMS systems | Product catalog, inventory, order history, and sellable item status. |
+| Web and app analytics sources | Browsing, search, product view, and add-to-cart signals. |
+| POS and clienteling systems | Store visits, appointments, stylist-assisted interactions, and client context. |
+| Email or marketing systems | Campaign activation and engagement data. |
+| Weather and calendar sources | Context signals for climate, season, holiday, and event-aware recommendations. |
+| Analytics or warehouse systems | Downstream analysis, model evaluation, and reporting. |
+
+## Key technical boundaries
+
+### Boundary 1: Source-of-record versus recommendation copy
+
+Upstream commerce and customer systems remain the source of truth for core product, inventory, and transaction records. The recommendation platform should maintain only the normalized data needed for decisioning, traceability, and analytics.
+
+### Boundary 2: Curated intent versus model-driven ranking
+
+Curated looks and merchandising rules define the allowable and preferred recommendation space. AI ranking should optimize within those constraints, not bypass them without explicit governance.
+
+### Boundary 3: Shared platform versus channel presentation
+
+The platform owns recommendation generation and metadata. Each consumer surface owns final rendering, copy treatment, and surface-specific interaction design, subject to UI standards.
+
+### Boundary 4: RTW versus CM logic
+
+RTW and CM should share ingestion, identity, context, telemetry, and delivery foundations. Compatibility logic and request inputs may differ where configured garments require more detailed state.
+
+### Boundary 5: Real-time serving versus offline computation
+
+Heavy data preparation, graph construction, and profile updates can run asynchronously. Shopper-facing recommendation requests must be served within a real-time API path using prepared data and bounded per-request computation.
+
+## Operational assumptions
+
+- Product and inventory data can be refreshed frequently enough to avoid surfacing unavailable items.
+- Customer behavior events are available with sufficient freshness to support recent-intent use cases.
+- Weather and event context should be cached or otherwise handled so external dependency latency does not dominate real-time serving.
+- Recommendation requests must degrade gracefully when identity, weather, or event data is missing.
+- Trace identifiers and recommendation set identifiers are required for support, analytics, and experimentation.
+
+## Implementation-oriented constraints
+
+- The architecture must support multiple recommendation types without separate endpoint contracts for every variant.
+- Recommendation outputs must contain structured item, look, and rationale metadata suitable for several channels.
+- The platform should not hard-code one source system or one channel as the only supported integration path.
+- Identity confidence and consent state must be available to decisioning or filtering logic where relevant.
+- Admin and governance capabilities are part of the product architecture, not an afterthought.
+
+## Architecture implications for later stages
+
+- Feature architecture will need explicit contracts for look storage, graph modeling, recommendation assembly, and telemetry.
+- Implementation planning will need clear separation between online serving components and offline data preparation jobs.
+- Integration work will need stable mappings between source-system IDs and canonical platform IDs.
+
+## Missing decisions
+
+- Missing decision: the primary storage pattern for look, graph, and profile data.
+- Missing decision: the boundary between in-request ranking and precomputed recommendation candidate generation.
+- Missing decision: whether experiment allocation occurs inside the recommendation service or in a shared experimentation layer.

--- a/docs/project/business-requirements.md
+++ b/docs/project/business-requirements.md
@@ -1,0 +1,160 @@
+# Business Requirements
+
+## Purpose
+
+Define the business-level requirements, scope boundaries, workflows, constraints, assumptions, and open questions for the AI Outfit Intelligence Platform.
+
+## Practical usage
+
+Use this document as the canonical product requirements source for later feature breakdown, architecture, and implementation planning.
+
+## Scope statement
+
+Build an AI Outfit Intelligence Platform for SuitSupply that supports RTW and CM recommendation scenarios, generates multiple recommendation types, and serves multiple customer and internal channels through a shared recommendation decisioning layer.
+
+The platform must combine curated merchandising intent with AI-driven personalization and contextual awareness so that recommendations are brand-safe, measurable, and commercially useful.
+
+## Target users
+
+### Primary users
+- online shoppers browsing suits, shirts, shoes, and accessories
+- returning customers with purchase history and style signals
+- occasion-driven customers shopping for weddings, business meetings, interviews, travel, and seasonal wardrobe needs
+
+### Secondary users
+- in-store stylists and clienteling teams
+- merchandisers curating looks, rules, and campaigns
+- marketing teams activating personalized recommendation content
+- product, analytics, and optimization teams improving recommendation outcomes
+
+## Business value
+
+This product is expected to create value by:
+- increasing conversion rate
+- increasing average order value and attach rate across categories
+- improving customer lifetime value through better personalization
+- increasing inspiration and discovery across channels
+- enabling merchandising control without giving up AI-driven optimization
+- differentiating SuitSupply from similarity-only recommendation competitors
+
+## In-scope product capabilities
+
+### Recommendation experience requirements
+
+| ID | Requirement |
+| --- | --- |
+| BR-001 | The platform must generate complete-look recommendations rather than only single-item similarity recommendations. |
+| BR-002 | The platform must support outfit, cross-sell, upsell, curated style bundle, occasion-based, contextual, and personal recommendation types. |
+| BR-003 | The platform must support recommendation delivery to PDP, cart, homepage or personalization surfaces, style inspiration or look builder pages, email campaigns, in-store clienteling interfaces, and future mobile or API-driven experiences. |
+| BR-004 | The platform must support both anonymous-session recommendation inputs and known-customer personalization when identity resolution is available. |
+| BR-005 | The platform must produce recommendations that are inventory-aware and suitable for active selling surfaces. |
+
+### Product, look, and compatibility requirements
+
+| ID | Requirement |
+| --- | --- |
+| BR-006 | The platform must ingest product catalog data including category, fabric, color, pattern, fit, season, occasion, style tags, price tier, inventory, imagery, and RTW or CM attributes. |
+| BR-007 | The platform must represent curated looks and product relationships in a way that supports complete-look recommendation assembly. |
+| BR-008 | The platform must support compatibility rules and business rules that constrain or prioritize recommendations. |
+| BR-009 | The platform must support RTW-specific recommendation logic for standard products and CM-specific logic for configured garments, style options, and premium selections. |
+
+### Customer, context, and intent requirements
+
+| ID | Requirement |
+| --- | --- |
+| BR-010 | The platform must ingest customer signals including orders, browsing behavior, page views, product views, add-to-cart events, search behavior, email engagement, loyalty or account behavior, store visits, appointments, stylist notes, and saved looks or wishlists where available. |
+| BR-011 | The platform must resolve identity across channels sufficiently to build and use a customer style profile. |
+| BR-012 | The platform must support customer profile, purchase affinity, segmentation, and intent-detection capabilities for recommendation decisions. |
+| BR-013 | The platform must use context signals including location, country, weather, season, holiday or event calendar, and session context where useful. |
+
+### Decisioning and delivery requirements
+
+| ID | Requirement |
+| --- | --- |
+| BR-014 | The platform must provide a recommendation engine that combines product relationships, curated looks, business rules, context, and customer signals. |
+| BR-015 | The platform must expose a recommendation delivery API that can accept inputs such as customer ID, product ID, context, location, and weather and return recommendation sets by type. |
+| BR-016 | Recommendation responses must include enough metadata for channel rendering, analytics attribution, experimentation, and troubleshooting. |
+| BR-017 | The platform must support recommendation fallbacks when customer data or context data is sparse or unavailable. |
+
+### Merchandising, analytics, and governance requirements
+
+| ID | Requirement |
+| --- | --- |
+| BR-018 | The platform must include merchandising controls for curated looks, rule management, campaign influence, and business overrides. |
+| BR-019 | The platform must support experimentation and A/B testing of recommendation strategies and channel placements. |
+| BR-020 | The platform must capture recommendation telemetry and analytics sufficient to measure impressions, engagement, conversion, and downstream revenue impact. |
+| BR-021 | The platform must support governance controls for privacy, consent handling, auditability, and brand-safe recommendation behavior. |
+| BR-022 | The platform must integrate with commerce, POS, marketing, and analytics systems needed to activate and measure recommendations across channels. |
+
+## Major workflows
+
+| Workflow ID | Workflow | Description |
+| --- | --- | --- |
+| WF-001 | Product-anchored recommendation | Generate complete looks and complementary items from a viewed product or cart context. |
+| WF-002 | Occasion-led recommendation | Generate looks from occasion, season, region, and weather context even when no anchor product is present. |
+| WF-003 | Personal recommendation | Generate recommendations using customer profile, purchase history, behavior, and intent signals. |
+| WF-004 | CM recommendation | Generate recommendations for configured garments, fabrics, style options, and premium add-ons. |
+| WF-005 | Merchandising control workflow | Allow merchandisers to define looks, rules, exclusions, and campaign priorities that influence recommendation outcomes. |
+| WF-006 | Measurement and optimization workflow | Capture recommendation exposure and outcome events, run experiments, and improve performance. |
+
+## Clear scope boundaries
+
+## In scope
+
+- complete-look recommendation logic
+- cross-category compatibility and outfit assembly
+- RTW and CM recommendation support
+- recommendation delivery API and channel consumption patterns
+- curated look ingestion and merchandising-rule management
+- customer signal, context signal, and product signal usage for recommendation decisions
+- experimentation, telemetry, analytics, and governance for recommendations
+
+## Out of scope for this bootstrap run
+
+- detailed downstream feature specifications
+- board seeding or issue fan-out
+- full implementation architecture for each subsystem
+- replacement of upstream systems such as Shopify, OMS, POS, email service provider, or weather provider
+- non-recommendation product areas such as search engine redesign or broad CMS replacement
+
+## Success measures
+
+| Area | Measure |
+| --- | --- |
+| Commercial impact | Conversion lift, average order value lift, attach rate, repeat purchase improvement. |
+| Recommendation quality | Recommendation coverage, click-through, save rate where supported, add-to-cart rate, purchase conversion, dismiss rate. |
+| Operational quality | Data freshness, rule execution accuracy, experiment readiness, API reliability, supportability. |
+| Channel effectiveness | Email recommendation engagement, clienteling adoption, homepage or PDP performance by surface. |
+
+## Constraints
+
+- Recommendations must remain stylistically credible and brand-safe.
+- The platform must coexist with existing commerce, CRM, retail, and analytics systems rather than replacing them.
+- Customer data usage must respect regional privacy and consent requirements.
+- Inventory and availability must influence recommendation eligibility on sellable surfaces.
+- RTW and CM logic may differ, but excessive platform duplication should be avoided.
+- The first phases should favor reusable foundations over one-off channel implementations.
+
+## Assumptions
+
+- SuitSupply can access the product, order, and behavioral data sources named in the issue, though readiness may vary by system.
+- Curated looks, styling rules, or merchandising knowledge can be represented in structured form.
+- Weather and event context can be sourced externally or derived internally when required.
+- Channel teams are willing to consume recommendation APIs rather than maintain entirely separate logic.
+- Attribution of recommendation impact will require a shared event model and recommendation set identifiers.
+
+## Open questions and missing decisions
+
+- Missing decision: which surfaces are mandatory for the first live release.
+- Missing decision: what customer identity graph or source of truth will anchor cross-channel profile resolution.
+- Missing decision: what minimum data freshness is required for inventory, weather, and customer-behavior signals.
+- Missing decision: what level of explainability should be exposed on customer-facing surfaces versus internal tools.
+- Missing decision: how CM configuration state will be passed into recommendation requests.
+- Missing decision: whether saved looks, favorites, and stylist notes are consistently available enough to include in the first production profile.
+- Missing decision: who owns approval for high-impact merchandising rules and campaign overrides.
+
+## Governance notes
+
+- Recommendation behavior should be auditable enough to explain which curated look, rule, context input, experiment, or model contributed to a recommendation set.
+- Human merchandising intent must be able to override purely model-driven outcomes where brand, campaign, or inventory considerations require it.
+- Any use of personal data for recommendations must align with consent state and regional policy.

--- a/docs/project/data-standards.md
+++ b/docs/project/data-standards.md
@@ -1,0 +1,105 @@
+# Data Standards
+
+## Purpose
+
+Define key data principles, identifier rules, event standards, privacy expectations, and auditability requirements for the AI Outfit Intelligence Platform.
+
+## Practical usage
+
+Use this document when designing catalog feeds, customer profiles, recommendation telemetry, experimentation data, analytics models, and integration mappings.
+
+## Key data principles
+
+1. Use stable canonical identifiers inside the platform.
+2. Preserve source-system mappings explicitly.
+3. Treat identity resolution confidence as data, not hidden logic.
+4. Capture enough recommendation metadata to support attribution and auditability.
+5. Respect consent and regional privacy requirements in data collection and recommendation usage.
+6. Prefer schema consistency across channels over channel-specific event fragmentation.
+
+## Canonical identifiers
+
+| Identifier | Purpose |
+| --- | --- |
+| `productId` | Canonical product identifier used by recommendation logic. |
+| `variantId` | Variant-level identifier when size, color, or other sellable distinctions matter. |
+| `lookId` | Canonical identifier for a curated or generated look definition. |
+| `customerId` | Canonical known-customer identifier after source mapping or identity resolution. |
+| `profileId` | Identifier for the recommendation-facing style profile record. |
+| `sessionId` | Identifier for anonymous or mixed-state browsing sessions. |
+| `recommendationSetId` | Identifier for a specific recommendation response delivered to a consumer. |
+| `ruleId` | Identifier for a merchandising rule or override. |
+| `campaignId` | Identifier for campaign influence or source context. |
+| `experimentId` | Identifier for an experiment definition. |
+| `variantKey` | Identifier for the experiment variant or strategy assignment. |
+| `traceId` | End-to-end diagnostic identifier for request, response, and outcome linkage. |
+
+## Data ownership expectations
+
+| Data domain | Expected source of truth | Platform responsibility |
+| --- | --- | --- |
+| Product and inventory | Commerce or OMS systems | Normalize and cache the fields needed for recommendation decisions. |
+| Orders and transactions | Commerce, OMS, or POS systems | Consume and join as customer and affinity signals. |
+| Behavioral events | Web, app, email, or store interaction sources | Normalize into a common event model. |
+| Customer profile | Identity or CRM sources plus platform-derived features | Maintain recommendation-facing profile features and confidence metadata. |
+| Curated looks and rules | Merchandising or admin workflows | Store and version recommendation-relevant look and rule entities. |
+| Experiment metadata | Experimentation tooling or platform controls | Preserve assignment and variant context for analysis. |
+
+## Event and telemetry standards
+
+Recommendation-related telemetry should support at least the following events:
+
+| Event | Required use |
+| --- | --- |
+| `recommendation_impression` | Recorded when a recommendation set is shown on a surface. |
+| `recommendation_click` | Recorded when a user selects a recommendation. |
+| `recommendation_save` | Recorded when a user saves or favorites a recommendation where supported. |
+| `recommendation_add_to_cart` | Recorded when a recommended item is added to cart. |
+| `recommendation_purchase` | Recorded when a recommended item or look contributes to purchase. |
+| `recommendation_dismiss` | Recorded when a recommendation is actively dismissed where the surface supports it. |
+| `recommendation_override` | Recorded when a stylist or merchandiser override changes the recommendation outcome. |
+
+### Required fields on recommendation telemetry
+
+- `eventTime`
+- `surface`
+- `recommendationType`
+- `recommendationSetId`
+- `traceId`
+- `productId` or `lookId` as applicable
+- `customerId` and/or `sessionId` as available
+- `experimentId` and `variantKey` when applicable
+- `ruleId` when a merchandising rule materially influenced the result
+
+## Identity resolution expectations
+
+- Preserve source identifiers separately from canonical IDs.
+- Record identity resolution confidence when profiles are merged across channels or systems.
+- Do not assume every anonymous event can be safely or deterministically joined to a known customer.
+- Profile usage in recommendation decisions should respect both confidence level and consent state.
+
+## Privacy and governance expectations
+
+- Only use customer data that is permitted for the relevant use case and region.
+- Respect opt-out and consent signals for personalization features.
+- Avoid exposing sensitive profile reasoning directly in customer-facing experiences.
+- Ensure role-based access to internal data views that include customer or stylist context.
+
+## Data freshness and quality expectations
+
+- Inventory-sensitive data must be fresh enough to avoid recommending unavailable products on sellable surfaces.
+- Behavioral signals used for recent-intent features should have a freshness target defined by later implementation planning.
+- Missing or delayed context data should trigger fallback logic rather than silent corruption of recommendation quality.
+- Data contracts should define required versus optional fields explicitly.
+
+## Auditability expectations
+
+- Recommendation decisions should be reconstructable at a practical level using recommendation set metadata, trace identifiers, rule context, and experiment context.
+- Curated look and merchandising-rule changes should be versioned or otherwise auditable.
+- Downstream analytics should be able to distinguish curated influence, rule influence, and model-driven influence when feasible.
+
+## Missing decisions
+
+- Missing decision: retention windows for raw events, derived profile features, and recommendation trace records.
+- Missing decision: whether stylist notes and appointment details require additional access controls beyond general customer-profile access.
+- Missing decision: which warehouse or analytical store will act as the durable measurement source of truth.

--- a/docs/project/goals.md
+++ b/docs/project/goals.md
@@ -1,0 +1,97 @@
+# Goals
+
+## Purpose
+
+Define the business, user, and operational goals for the AI Outfit Intelligence Platform, along with measurable success criteria and explicit non-goals.
+
+## Practical usage
+
+Use this document to:
+- evaluate scope decisions against intended business value
+- guide roadmap prioritization
+- give later feature and architecture work a common definition of success
+
+## Business goals
+
+| Goal | Outcome sought | Notes |
+| --- | --- | --- |
+| Increase conversion rate | Improve shopper confidence and reduce friction in outfit completion decisions. | Target direction from issue: +5% to +10%. |
+| Increase average order value | Grow basket size through relevant cross-category recommendations. | Target direction from issue: +10% to +25%. |
+| Increase customer lifetime value | Improve repeat engagement and future purchase relevance through personal recommendations. | Requires strong profile and telemetry loop. |
+| Improve channel effectiveness | Raise performance of email, clienteling, and personalization programs with shared recommendation logic. | Should reduce fragmented channel-specific logic. |
+| Strengthen brand differentiation | Offer a styling experience competitors cannot match with similarity-only recommenders. | Must preserve SuitSupply brand voice and styling quality. |
+
+## User goals
+
+### Primary user goals
+
+- Build a complete outfit with less guesswork.
+- Understand which complementary items are stylistically compatible.
+- Receive recommendations appropriate for occasion, weather, location, and season.
+- See suggestions that reflect past purchases and personal style when known.
+- Move from inspiration to purchase across multiple categories without restarting discovery.
+
+### Secondary user goals
+
+- Stylists and client advisors can assemble credible looks faster during assisted selling.
+- Merchandisers can shape recommendation behavior through curated looks and merchandising rules.
+- Marketing teams can activate the same recommendation logic in lifecycle and campaign messaging.
+- Product and analytics teams can test, measure, and improve recommendation performance over time.
+
+## Operational goals
+
+| Goal | What operational success looks like |
+| --- | --- |
+| Reliable data ingestion | Product, event, and customer data arrive with predictable freshness and quality. |
+| Shared decisioning layer | Recommendation logic is reusable across web, email, clienteling, and future API consumers. |
+| Merchandising control | Teams can define curated looks, overrides, exclusions, and campaign priorities without engineering intervention for every change. |
+| Experimentation readiness | Recommendation variants can be measured and compared with clear telemetry. |
+| Governance readiness | Consent, privacy, auditability, and decision traceability are built into the platform. |
+| RTW and CM extensibility | Core platform services support both modes without duplicating the entire stack. |
+
+## Success criteria
+
+## Outcome metrics
+
+| Metric | Success direction | Source |
+| --- | --- | --- |
+| Conversion rate on recommendation-enabled surfaces | Increase | Issue target: +5% to +10%. |
+| Average order value | Increase | Issue target: +10% to +25%. |
+| Attach rate for complementary categories | Increase | Particularly shirts, ties, shoes, belts, outerwear, and accessories. |
+| Repeat purchase rate from personalized cohorts | Increase | Indicates longer-term style relevance. |
+| Email or clienteling recommendation engagement | Increase | Applies to click-through and assisted-sell usage. |
+
+## Operating metrics
+
+| Metric | Success direction | Notes |
+| --- | --- | --- |
+| Recommendation coverage | High | Each supported surface should have a valid fallback path when data is sparse. |
+| Inventory-aware recommendation rate | High | Recommendations should prefer currently sellable items. |
+| Recommendation API latency | Low | Must be fast enough for real-time shopper surfaces; exact threshold is a missing decision. |
+| Experiment readout quality | High | Events must link impression to click, add-to-cart, purchase, and dismiss behavior. |
+| Merchandising override application accuracy | High | Curated and rule-based intent must be honored predictably. |
+
+## Non-goals
+
+The bootstrap scope does **not** assume the platform will:
+- replace human stylists or merchandising judgment
+- auto-generate customer-facing fashion advice without governance
+- optimize only for popularity or co-occurrence at the expense of styling compatibility
+- require every channel to launch at once before any value is delivered
+- solve full content management, campaign authoring, or ecommerce search as separate product areas
+- introduce a fully autonomous CM design assistant in the initial platform scope
+
+## Prioritization guardrails
+
+When goals conflict, prioritize in this order:
+1. brand-safe and stylistically credible recommendations
+2. shopper and stylist usefulness on high-value surfaces
+3. measurable commercial lift
+4. cross-channel reuse
+5. deeper automation and optimization
+
+## Missing decisions
+
+- Missing decision: which surfaces must be included in the first live release versus later phases.
+- Missing decision: exact service-level objectives for API latency, freshness, and availability.
+- Missing decision: baseline measurement definitions for conversion, attach rate, and attributable revenue lift.

--- a/docs/project/integration-standards.md
+++ b/docs/project/integration-standards.md
@@ -1,0 +1,75 @@
+# Integration Standards
+
+## Purpose
+
+Define the principles and operational expectations for integrations that supply data to or consume outputs from the AI Outfit Intelligence Platform.
+
+## Practical usage
+
+Use this document when designing contracts with commerce systems, POS or clienteling platforms, marketing tools, weather providers, analytics stores, and downstream recommendation consumers.
+
+## Integration principles
+
+1. Prefer explicit contracts over inferred field usage.
+2. Preserve canonical platform identifiers alongside source-system identifiers.
+3. Keep recommendation-serving paths resilient to slow or degraded upstream dependencies.
+4. Design integrations for observability, replay where appropriate, and safe retries.
+5. Avoid channel-specific one-off integrations when a shared contract will work.
+
+## Integration categories
+
+| Category | Typical systems | Primary responsibility |
+| --- | --- | --- |
+| Commerce and OMS | Shopify, OMS, inventory services | Provide product, order, pricing, and inventory data. |
+| Web and app event sources | Web analytics, tag streams, app telemetry | Provide shopper behavior and session signals. |
+| POS and clienteling | Store systems, appointment tools, advisor apps | Provide in-store context, assisted-selling signals, and appointment data. |
+| Marketing and CRM | Email platforms, audience tools | Consume recommendations and provide engagement outcomes. |
+| Context providers | Weather, holiday, or event data sources | Supply external context used by recommendation logic. |
+| Analytics and warehouse | Reporting and modeling stores | Consume telemetry and support measurement. |
+
+## Authentication and secret handling
+
+- Use managed secrets and service credentials appropriate to each integration.
+- Never hard-code credentials in application code, documentation examples, or exported payloads.
+- Rotate secrets according to the owning platform's policy.
+- Scope integration credentials by environment and least privilege.
+
+## Retries, timeouts, and idempotency guidance
+
+- Treat context-provider calls as bounded-latency dependencies; use caching or asynchronous enrichment where possible.
+- Retries must be safe and should respect idempotency constraints on write operations.
+- Event ingestion and webhook processing should support duplicate detection or idempotency keys.
+- Recommendation-serving paths should degrade to fallback behavior rather than block indefinitely on optional context integrations.
+
+## Observability expectations
+
+- Log integration errors with enough context to identify the source system, contract version, and affected entity set.
+- Propagate `traceId` where possible across integrated flows.
+- Track freshness, failure rate, and processing lag for critical inbound data feeds.
+- Alert on integration failures that materially degrade recommendation quality or coverage.
+
+## Dependency management expectations
+
+- Document ownership for each integration and the contract change process.
+- Version schemas or payload shapes when breaking changes are possible.
+- Test contract changes before promoting them to shared environments.
+- Prefer additive changes to shared contracts.
+
+## Data and contract expectations
+
+- Explicitly distinguish required and optional fields.
+- Preserve source-system timestamps and identifiers for audit and reconciliation.
+- Normalize category, season, occasion, and style-related values to shared platform vocabularies where possible.
+- When an upstream source cannot meet platform needs, record the gap as a missing decision or delivery dependency.
+
+## Fallback behavior
+
+- If weather or event context is unavailable, continue with season or location-based fallback logic when possible.
+- If a non-critical engagement feed is delayed, continue serving recommendations using the last trusted profile or generic logic.
+- If inventory freshness is uncertain, surfaces should prefer safer recommendation sets or lower-confidence display patterns based on later implementation rules.
+
+## Missing decisions
+
+- Missing decision: which commerce, CRM, POS, and analytics platforms define the initial integration perimeter.
+- Missing decision: whether weather and event context are sourced from third-party providers or internal data products.
+- Missing decision: what replay and backfill tooling will be available for failed ingestion flows.

--- a/docs/project/personas.md
+++ b/docs/project/personas.md
@@ -1,0 +1,58 @@
+# Personas
+
+## Purpose
+
+Capture the primary and secondary personas that the AI Outfit Intelligence Platform must serve, including their goals, pain points, behaviors, and definition of success.
+
+## Practical usage
+
+Use this document to:
+- check whether proposed features solve a real user problem
+- shape workflows for shopper, stylist, merchandising, and marketing surfaces
+- keep later requirements grounded in real decision-making contexts
+
+## Primary personas
+
+| Persona | Goals | Pain points | Behaviors | Decision-making context | What success looks like |
+| --- | --- | --- | --- | --- | --- |
+| **P1. Occasion-led online shopper** | Find a complete outfit for a wedding, interview, business meeting, travel, or seasonal need. | Unsure which items work together; fears getting formality or color combinations wrong; does not want to browse every category manually. | Starts with an occasion, hero product, or inspiration image; compares options quickly; may buy across multiple categories in one session. | Needs recommendations that balance style coherence, occasion fit, seasonality, and ease of purchase. | Can move from one entry point to a credible outfit with minimal guesswork. |
+| **P2. Returning style-aware customer** | Extend or refresh wardrobe with pieces that fit prior purchases and personal taste. | Gets generic recommendations that ignore purchase history, closet context, or preferred silhouettes; does not want redundant suggestions. | Logs in, revisits previously browsed categories, reacts well to personal recommendations in web and email. | Expects the platform to recognize existing style profile and recommend complementary items rather than generic bestsellers. | Sees recommendations that feel tailored, relevant, and worth acting on. |
+| **P3. Custom Made customer** | Configure shirts, ties, fabrics, and premium options that complement a custom garment or appointment context. | CM choices are more complex; compatibility is harder to judge; generic RTW suggestions can feel mismatched. | Engages in longer consideration cycles, often with higher intent; may shop with appointment, stylist, or event context. | Needs recommendation logic that respects CM attributes, color palettes, premium options, and compatibility with configured garments. | Receives guided CM recommendations that reduce decision fatigue and increase confidence in premium selections. |
+
+## Secondary personas
+
+| Persona | Goals | Pain points | Behaviors | Decision-making context | What success looks like |
+| --- | --- | --- | --- | --- | --- |
+| **S1. In-store stylist or client advisor** | Build looks quickly, personalize advice, and increase basket size during assisted selling. | Manual look assembly is time-consuming; digital tools may not reflect real inventory, context, or prior purchases. | Uses clienteling tools before and during appointments; combines platform suggestions with human judgment. | Needs trustworthy, inventory-aware recommendations that can be edited or overridden. | Can use platform recommendations as a fast starting point rather than rebuilding every outfit manually. |
+| **S2. Merchandiser** | Publish curated looks, define merchandising rules, and control campaign emphasis. | Rules and curated intent are hard to scale consistently across surfaces; manual updates do not propagate well. | Thinks in seasonal collections, look stories, category priorities, and exclusions. | Needs clear control over how curated, rule-based, and AI-ranked recommendations interact. | Can steer recommendation behavior without slowing delivery or requiring custom engineering. |
+| **S3. Marketing or CRM manager** | Send more relevant recommendation emails and journey-based follow-ups. | Channel logic is fragmented; recommendations may not reflect current inventory or customer intent. | Works with campaign audiences, triggers, and performance metrics. | Needs a reusable recommendation service and metadata suitable for campaign assembly and measurement. | Can activate personalized looks and complementary products with measurable lift. |
+| **S4. Product, analytics, or optimization lead** | Measure recommendation performance and improve the system over time. | Hard to attribute results when surfaces, rules, and data are inconsistent. | Defines KPIs, experiments, telemetry, and rollout decisions. | Needs traceable recommendation decisions, experiment hooks, and reliable event data. | Can determine which recommendation strategies improve business outcomes and why. |
+
+## Persona priorities for early delivery
+
+The first delivery phases should optimize for:
+1. P1 Occasion-led online shopper
+2. P2 Returning style-aware customer
+3. S1 In-store stylist or client advisor
+
+These personas are most directly connected to conversion, average order value, and visible recommendation quality on core channels.
+
+## Shared needs across personas
+
+Across shopper and internal personas, the platform must provide:
+- credible complete-look recommendations rather than isolated product suggestions
+- visibility into why a recommendation is relevant, at least through reason codes or contextual labeling
+- inventory-aware outputs that can actually be sold or used in clienteling
+- a clear path for curated looks and merchandising rules to shape outcomes
+- measurable events that connect recommendation delivery to downstream behavior
+
+## Risks if personas are underspecified
+
+- shopper experiences may overfit to one channel and fail in assisted selling or CRM use cases
+- CM needs may be lost if RTW-only logic becomes the default mental model
+- merchandising and governance needs may be treated as afterthoughts, creating brand and operational risk
+
+## Missing decisions
+
+- Missing decision: whether saved looks, wishlists, and stylist notes exist consistently enough to include in first-release profile logic.
+- Missing decision: how strongly the first release should optimize for stylist workflows versus shopper self-service journeys.

--- a/docs/project/problem-statement.md
+++ b/docs/project/problem-statement.md
@@ -1,0 +1,89 @@
+# Problem Statement
+
+## Purpose
+
+Describe the customer and business problem the AI Outfit Intelligence Platform must solve, why current approaches are insufficient, and what happens if the problem remains unresolved.
+
+## Practical usage
+
+Use this document to:
+- justify why the product deserves investment
+- keep later requirements focused on the real user problem
+- explain why complete-look recommendation is a separate category from generic ecommerce recommendation
+
+## Current problem
+
+SuitSupply customers often shop with outfit-level intent, but most ecommerce recommendation patterns support item-level discovery. A shopper may know they need a suit for a wedding, an interview, or business travel, yet the digital experience often helps only with similar products or generic "frequently bought together" suggestions.
+
+This creates a mismatch between customer intent and recommendation behavior:
+- customers think in looks and occasions
+- most recommendation systems think in isolated SKUs and aggregate co-occurrence
+
+As a result, customers are left to answer styling and compatibility questions on their own, even though SuitSupply already has strong styling knowledge that could guide the decision.
+
+## Who experiences the problem
+
+### Primary audiences
+
+- online shoppers trying to build a full outfit across suits, shirts, shoes, and accessories
+- returning customers who expect recommendations to reflect past purchases or style preferences
+- customers shopping for a specific occasion, climate, or season
+
+### Secondary audiences
+
+- in-store stylists and client advisors who need fast, credible look suggestions
+- merchandisers trying to scale curated looks and brand guardrails
+- marketing teams trying to send personalized recommendations without fragmented logic
+- product and analytics teams that need measurable recommendation performance
+
+## Why current alternatives are insufficient
+
+Current recommendation approaches usually optimize for one of the following:
+- similar products
+- co-purchase frequency
+- popularity
+- generic personalization without styling compatibility
+
+Those approaches are insufficient because they do not reliably answer:
+- whether items form a coherent outfit
+- whether a recommendation fits an occasion or dress code
+- whether climate, weather, and season should change the recommendation
+- how a previous purchase should influence complementary pieces
+- how curated merchandising intent should interact with AI ranking
+
+They also fail to create a shared decisioning layer that can power web, email, clienteling, and future surfaces consistently.
+
+## Why now
+
+Several conditions make the problem timely:
+- SuitSupply already has brand-specific style expertise worth operationalizing
+- customer expectations for personalized ecommerce experiences continue to rise
+- the product opportunity spans multiple revenue levers: conversion, average order value, and repeat purchase
+- recommendation infrastructure can now combine rules, graphs, context, and AI ranking more effectively than earlier similarity-only systems
+- multiple channels need consistent logic rather than isolated recommendation implementations
+
+## Root causes the platform must address
+
+1. **No complete-look decision model.** Existing recommendation logic does not reason over outfit compatibility as a first-class problem.
+2. **Weak context usage.** Location, weather, season, and occasion are not consistently reflected in recommendations.
+3. **Fragmented customer understanding.** Purchase history, browsing behavior, and other style signals are not unified into a usable style profile.
+4. **Limited merchandising activation.** Curated looks and business rules are not easily activated at scale across channels.
+5. **Insufficient feedback loop.** Recommendation performance is difficult to optimize without shared telemetry and experimentation.
+
+## Consequence of not solving it
+
+If SuitSupply does not solve this problem:
+- shoppers will continue to abandon outfit-building decisions or buy fewer complementary items
+- revenue uplift from cross-sell and upsell opportunities will remain under-realized
+- brand differentiation will be weaker than it could be in a premium menswear journey
+- stylists, merchandisers, and marketers will keep relying on fragmented manual processes
+- future personalization efforts will be harder to scale because the platform layer is missing
+
+## Problem statement summary
+
+SuitSupply needs a governed, context-aware outfit intelligence platform that can translate product knowledge, style curation, customer behavior, and channel context into complete-look recommendations across RTW and CM journeys. Without that platform, the business will continue to operate with item-level recommendation logic that does not match how customers actually shop.
+
+## Missing decisions
+
+- Missing decision: how much anonymous-session personalization is expected before identity resolution occurs.
+- Missing decision: which occasion taxonomy and style vocabulary should be standardized across merchandising and customer-facing surfaces.

--- a/docs/project/product-overview.md
+++ b/docs/project/product-overview.md
@@ -1,0 +1,140 @@
+# Product Overview
+
+## Purpose
+
+Provide a high-level description of what the AI Outfit Intelligence Platform is, how users interact with it, which surfaces it powers, and where the product boundaries sit.
+
+## Practical usage
+
+Use this document to:
+- orient downstream feature and architecture work
+- understand the end-to-end product shape without diving into implementation detail
+- keep channels and workflows aligned to one platform concept
+
+## What the product is
+
+The AI Outfit Intelligence Platform is a recommendation and decisioning layer for SuitSupply that generates complete-look and complementary-product recommendations across multiple customer and business surfaces.
+
+The platform combines:
+- curated looks and styling knowledge
+- merchandising rules and business constraints
+- customer behavior and purchase signals
+- contextual inputs such as location, weather, season, and occasion
+- AI ranking and optimization
+
+It serves both:
+- **RTW** journeys, where recommendations are based on standard catalog products
+- **CM** journeys, where recommendations must account for configured garments, style options, and premium selections
+
+## Recommendation types
+
+The platform must support the following recommendation types:
+- outfit recommendations
+- cross-sell recommendations
+- upsell recommendations
+- curated style bundles
+- occasion-based recommendations
+- contextual recommendations
+- personal recommendations based on customer profile and behavior
+
+## Primary surfaces and channels
+
+| Surface or channel | Primary use |
+| --- | --- |
+| Product detail page | Recommend complete looks and complementary items anchored to the current product. |
+| Cart | Fill outfit gaps, suggest finishing items, and raise attach rate before checkout. |
+| Homepage or web personalization | Present look-led entry points and intent-aware recommendations for known or anonymous visitors. |
+| Style inspiration or look builder pages | Support top-of-funnel discovery and complete-look exploration. |
+| Email campaigns | Deliver personalized looks or follow-up cross-sell recommendations. |
+| In-store clienteling interfaces | Help stylists assemble or refine looks during appointments and assisted selling. |
+| Future mobile or API-driven experiences | Reuse the same recommendation platform in new channels without rebuilding the logic. |
+
+## Major user journeys
+
+### Journey 1: Product-anchored outfit completion
+
+1. Shopper views a hero item such as a suit or jacket.
+2. Platform identifies compatible items across shirts, ties, shoes, belts, outerwear, and accessories.
+3. Recommendation service returns one or more complete looks and cross-sell options.
+4. Shopper evaluates the outfit and adds selected items to cart.
+
+### Journey 2: Occasion-led discovery
+
+1. Shopper arrives with an occasion or seasonal need.
+2. Platform interprets occasion, climate, and region context.
+3. Experience presents one or more relevant looks and category pathways.
+4. Shopper refines and purchases the outfit.
+
+### Journey 3: Returning-customer personalization
+
+1. Known customer browses or opens a campaign.
+2. Platform uses purchase history, browsing behavior, and style profile signals.
+3. Recommendations prioritize compatible pieces that extend the existing wardrobe.
+4. Outcomes feed back into the customer profile and optimization loop.
+
+### Journey 4: Assisted selling and clienteling
+
+1. Stylist opens a customer profile, appointment context, or current basket.
+2. Platform returns curated and personalized look suggestions.
+3. Stylist adjusts the look using human judgment and store-specific realities.
+4. Interaction outcomes are captured for future analysis when supported.
+
+### Journey 5: Merchandising and optimization
+
+1. Merchandiser defines curated looks, rules, exclusions, and campaign priorities.
+2. Product and analytics teams monitor recommendation performance and experiments.
+3. Updated rules, looks, and model behavior improve future recommendation sets.
+
+## Major workflows
+
+| Workflow | Description |
+| --- | --- |
+| Catalog and look ingestion | Ingest product attributes, curated looks, and RTW or CM compatibility metadata. |
+| Signal capture and profile building | Collect browsing, purchase, engagement, and stylist-related signals into a usable style profile. |
+| Context resolution | Turn location, season, weather, and occasion clues into usable recommendation inputs. |
+| Recommendation generation | Combine graph logic, rules, context, and ranking to produce recommendation sets. |
+| Delivery and rendering | Expose recommendations to web, email, clienteling, and future consumers. |
+| Measurement and optimization | Track outcomes, run experiments, and improve recommendation quality over time. |
+
+## Major capability areas
+
+| Capability area | What it covers |
+| --- | --- |
+| Product and catalog intelligence | Product attributes, imagery, season, occasion, inventory, RTW and CM metadata. |
+| Customer intelligence | Identity resolution, customer profile, purchase affinity, segmentation, and intent signals. |
+| Look and compatibility modeling | Curated looks, product relationship graph, compatibility rules, and outfit logic. |
+| Context engine | Weather, location, country, season, holiday, and event-aware decision inputs. |
+| Recommendation engine | Candidate generation, ranking, rule application, and recommendation set assembly. |
+| Delivery layer | Recommendation API and downstream channel integrations. |
+| Merchandising and governance | Rule builder, curation controls, campaign controls, approvals, and guardrails. |
+| Analytics and experimentation | Telemetry, A/B testing, insight generation, and performance reporting. |
+
+## High-level product boundaries
+
+## In bounds
+
+- recommendation decisioning and delivery
+- curated look and compatibility modeling
+- customer, product, and context signal usage for recommendation purposes
+- merchandising controls and business-rule application
+- telemetry, experimentation, and recommendation analytics
+- channel integrations needed to serve recommendation outcomes
+
+## Out of bounds at bootstrap
+
+- replacing core commerce, OMS, POS, or marketing platforms
+- full editorial content management systems
+- full search and browse platform redesign
+- fully autonomous style advice without human or brand guardrails
+- downstream feature-by-feature delivery planning
+
+## Product boundary notes
+
+- The platform may depend on upstream systems for source data, but it owns the recommendation decisioning layer.
+- Channel experiences may present recommendations differently, but should use the same underlying recommendation concepts and event model.
+- RTW and CM can differ in compatibility logic, yet should share core platform services where possible.
+
+## Missing decisions
+
+- Missing decision: whether the first live recommendation experience should launch on PDP only or include cart and homepage from the start.
+- Missing decision: whether a dedicated look builder surface is part of early delivery or a later expansion phase.

--- a/docs/project/roadmap.md
+++ b/docs/project/roadmap.md
@@ -1,0 +1,190 @@
+# Roadmap
+
+## Purpose
+
+Describe a phased delivery path for the AI Outfit Intelligence Platform, including recommended sequencing, dependencies, and review checkpoints.
+
+## Practical usage
+
+Use this document to:
+- decide what should be built earlier versus later
+- guide future issue fan-out and implementation planning
+- identify prerequisite platform work before broader channel rollout
+
+## Roadmap principles
+
+1. Build the shared data and decisioning foundation before multiplying channels.
+2. Prove commercial value on high-leverage surfaces early.
+3. Keep curated look support and merchandising controls available from the start.
+4. Expand personalization depth only after telemetry and identity foundations are usable.
+5. Add CM-specific sophistication after the core RTW recommendation platform is stable enough to reuse.
+
+## Recommended phased delivery order
+
+| Phase | Theme | Why it comes here first |
+| --- | --- | --- |
+| Phase 0 | Platform foundations and standards | Every later capability depends on shared catalog, event, identity, API, and telemetry decisions. |
+| Phase 1 | Curated and rule-based recommendation MVP | Delivers visible value quickly while keeping recommendation behavior controllable and brand-safe. |
+| Phase 2 | Personalization and context-aware ranking | Builds on stable delivery, telemetry, and profile foundations to improve relevance. |
+| Phase 3 | Channel expansion and CM depth | Extends the platform to more workflows once core logic is proven. |
+| Phase 4 | Optimization, automation, and mature governance | Scales experimentation, insights, and operational controls after the platform is live in multiple contexts. |
+
+## Phase details
+
+### Phase 0: Platform foundations and standards
+
+**Key themes**
+- canonical product, look, and recommendation concepts
+- data ingestion for product, customer, and context signals
+- identity and profile foundations
+- delivery API shape
+- telemetry and experimentation standards
+
+**Primary outputs**
+- product and look data model
+- event model and recommendation telemetry design
+- initial recommendation API contract
+- baseline architecture and integration contracts
+- governance and privacy guardrails
+
+**Dependencies**
+- access to upstream catalog, order, and behavioral data sources
+- alignment on canonical identifiers and source-system mappings
+
+**Checkpoint before advancing**
+- shared product and data standards reviewed
+- core API contract direction reviewed
+- recommendation telemetry plan reviewed
+
+### Phase 1: Curated and rule-based recommendation MVP
+
+**Key themes**
+- complete-look assembly from curated looks and compatibility rules
+- inventory-aware recommendation delivery
+- initial high-value surfaces such as PDP and cart
+- merchandising controls for curated content and overrides
+
+**Primary outputs**
+- first live recommendation service
+- support for outfit and cross-sell recommendation types
+- curated look ingestion and rule application
+- initial operational dashboards and support diagnostics
+
+**Dependencies**
+- Phase 0 API, data, and telemetry decisions
+- channel consumer integration for chosen first surfaces
+
+**Checkpoint before advancing**
+- recommendation sets are measurable end-to-end
+- merchandisers can influence outcomes without code changes for common cases
+- fallback behavior works when signals are sparse
+
+### Phase 2: Personalization and context-aware ranking
+
+**Key themes**
+- customer profile usage
+- purchase affinity and intent detection
+- weather, season, location, and occasion-aware ranking
+- experimentation on ranking and placement strategies
+
+**Primary outputs**
+- personal recommendation logic for known customers
+- context engine integration
+- ranking improvements beyond static curated order
+- experiment framework for recommendation variants
+
+**Dependencies**
+- stable telemetry linking impression to business outcome
+- usable identity resolution and profile confidence
+
+**Checkpoint before advancing**
+- uplift can be measured by cohort, strategy, and surface
+- context-aware recommendations outperform simpler baselines where tested
+
+### Phase 3: Channel expansion and CM depth
+
+**Key themes**
+- email and clienteling expansion
+- homepage or broader personalization surfaces
+- CM-specific recommendation logic and configuration inputs
+- wider reuse of the shared platform across teams
+
+**Primary outputs**
+- recommendation delivery patterns for CRM and clienteling
+- CM-compatible recommendation requests and outputs
+- broader channel templates and integration patterns
+
+**Dependencies**
+- Phase 1 and Phase 2 platform stability
+- clear CM attribute model and channel-specific rendering needs
+
+**Checkpoint before advancing**
+- non-web channels consume recommendation outputs with consistent metadata
+- CM recommendations meet styling and operational review standards
+
+### Phase 4: Optimization, automation, and mature governance
+
+**Key themes**
+- deeper analytics and insight tooling
+- advanced experimentation and automated optimization
+- stronger governance, approvals, and audit tooling
+- operational scaling across regions, campaigns, and assortments
+
+**Primary outputs**
+- robust analytics and insight workflows
+- recommendation quality monitoring and alerting
+- richer admin and governance interfaces
+- mature rollout and control patterns across channels
+
+**Dependencies**
+- live usage across several surfaces
+- reliable measurement and support processes
+
+**Checkpoint for maturity**
+- the platform can explain, measure, and improve recommendation decisions across channels without fragmented logic
+
+## Earlier versus later scope guidance
+
+### Do earlier
+
+- canonical identifiers and data ownership
+- recommendation set and trace identifiers
+- curated look ingestion
+- merchandising override model
+- inventory-aware eligibility rules
+- fallback recommendation behavior
+- surface instrumentation for recommendation outcomes
+
+### Do later
+
+- advanced model-driven optimization without adequate telemetry
+- highly channel-specific custom logic that bypasses shared standards
+- deep CM logic before RTW platform primitives are stable
+- broad automation of governance workflows before rule ownership is clear
+
+## Cross-phase dependencies
+
+| Dependency | Why it matters |
+| --- | --- |
+| Product and look data model | Needed before recommendation graph and channel rendering can be stable. |
+| Identity and profile model | Needed before meaningful personal recommendation logic can be trusted. |
+| Recommendation telemetry | Needed before experiments and optimization claims are credible. |
+| Merchandising controls | Needed before AI ranking can operate safely in production. |
+| Integration contracts | Needed before more channels can adopt the platform without one-off work. |
+
+## Practical test and review checkpoints
+
+| Checkpoint | What to validate |
+| --- | --- |
+| Data readiness review | Required source feeds, identifiers, and freshness assumptions are viable. |
+| Recommendation quality review | Recommendations are stylistically coherent, inventory-aware, and aligned with merchandising intent. |
+| API contract review | Delivery API supports chosen surfaces and traceability needs. |
+| Telemetry review | Impression-to-outcome linkage is sufficient for optimization. |
+| Channel readiness review | Each consuming surface can render and measure recommendation outputs correctly. |
+| Governance review | Consent, overrides, approval ownership, and auditability are sufficiently defined. |
+
+## Missing decisions
+
+- Missing decision: which specific surfaces define the minimum viable commercial launch.
+- Missing decision: whether CM depth belongs in the first multi-channel rollout or after RTW stabilization.
+- Missing decision: which team owns the initial merchandising admin experience versus lightweight rule configuration.

--- a/docs/project/standards.md
+++ b/docs/project/standards.md
@@ -1,0 +1,153 @@
+# Standards
+
+## Purpose
+
+Define the cross-cutting delivery, documentation, naming, lifecycle, and quality standards for the AI Outfit Intelligence Platform project.
+
+## Practical usage
+
+Use this document as the default standards reference when creating requirements, architecture, plans, reviews, APIs, data contracts, UI artifacts, integrations, and board items.
+
+## Cross-cutting principles
+
+1. Prefer implementation-oriented documentation over general summaries.
+2. Record missing decisions explicitly; do not hide uncertainty or invent unsupported detail.
+3. Keep recommendation behavior brand-safe, measurable, and traceable.
+4. Treat curated looks, merchandising rules, and AI ranking as complementary layers, not competing systems.
+5. Reuse shared platform contracts across channels whenever possible.
+6. Build RTW and CM on shared foundations while allowing targeted logic differences.
+7. Preserve clear boundaries between source systems, platform intelligence, and surface rendering.
+
+## Required domain terminology
+
+Use these terms consistently across project artifacts:
+
+| Term | Meaning |
+| --- | --- |
+| `look` | The internally modeled grouping of compatible products and recommendation logic inputs. |
+| `outfit` | The customer-facing complete-look concept presented on a surface. |
+| `style profile` | The structured representation of customer taste, purchase history, behavior, and inferred preferences used for recommendation decisions. |
+| `recommendation` | Any platform-generated suggestion, including outfit, cross-sell, upsell, contextual, or personal outputs. |
+| `merchandising rule` | A governed business rule that constrains, prioritizes, excludes, or boosts recommendation outcomes. |
+| `RTW` | Ready-to-Wear catalog recommendation context. |
+| `CM` | Custom Made recommendation context for configured garments and premium options. |
+
+## Naming and structure expectations
+
+### Repository documentation
+
+- Canonical project-level source-of-truth docs live in `docs/project/`.
+- Future feature deep-dives should live outside the bootstrap doc set and reference the relevant project docs.
+- File names should use lowercase with hyphens.
+- Operational documents should begin with a clear purpose and practical usage section.
+
+### Identifier conventions
+
+- Use stable canonical IDs for products, customers, looks, rules, campaigns, experiments, recommendation sets, and trace records.
+- Preserve source-system ID mappings explicitly rather than overloading one external ID as universal truth.
+- Requirement and workflow identifiers should use readable prefixes such as `BR-001` and `WF-001`.
+
+## Lifecycle and status expectations
+
+Use lifecycle states exactly as follows:
+- `TODO`
+- `IN_PROGRESS`
+- `NEEDS_REVIEW`
+- `IN_REVIEW`
+- `CHANGES_REQUESTED`
+- `READY_FOR_HUMAN_APPROVAL`
+- `APPROVED`
+- `DONE`
+
+Do not invent substitutes or abbreviations for these states in project artifacts or boards.
+
+## Documentation expectations
+
+- Every source-of-truth document should be understandable on its own and link back to upstream intent where relevant.
+- Separate confirmed decisions, assumptions, and missing decisions.
+- Call out dependencies, readiness criteria, and exit criteria when an artifact will drive downstream work.
+- Prefer structured tables for requirements, phases, integrations, and metrics.
+- Keep terminology consistent across vision, requirements, roadmap, architecture, and standards.
+
+## Traceability expectations
+
+- Business requirements should be traceable to later feature and architecture work.
+- Recommendation surfaces, recommendation types, and major workflows should use stable names across artifacts.
+- Recommendation events should preserve recommendation set identifiers and trace identifiers through downstream outcomes.
+- If assumptions change, affected upstream and downstream artifacts should be updated together.
+
+## Quality expectations
+
+All project artifacts should be:
+- clear enough that a later agent can act without guessing
+- complete enough to support downstream planning
+- explicit about dependencies and missing decisions
+- consistent with the documented product scope
+- cautious about privacy, governance, and automation authority
+
+## Cross-cutting standards by discipline
+
+### API expectations
+
+- Recommendation APIs should use stable versioned contracts.
+- Requests should accept structured context rather than channel-specific ad hoc parameters.
+- Responses should include metadata for rendering, tracing, experimentation, and outcome measurement.
+- Error handling should be predictable and machine-readable.
+
+See also: `docs/project/api-standards.md`.
+
+### Data expectations
+
+- Event and entity schemas must use canonical identifiers and source mappings.
+- Identity resolution confidence must be explicit where profile merges are not deterministic.
+- Consent and regional privacy constraints must be represented in data use decisions.
+- Recommendation outcome telemetry must support impression-to-purchase analysis.
+
+See also: `docs/project/data-standards.md`.
+
+### UI expectations
+
+- Customer-facing surfaces should present recommendations in a way that emphasizes complete looks and clear next actions.
+- Internal tools should surface recommendation context, rule influence, and actionable overrides where relevant.
+- Loading, empty, fallback, and unavailable states must be designed intentionally.
+
+See also: `docs/project/ui-standards.md`.
+
+### Integration expectations
+
+- External dependencies must have clear contracts, ownership, retry behavior, and observability.
+- Recommendation-serving paths should not depend on unbounded latency from third-party context providers.
+- Integration changes should be versioned and tested to avoid silent recommendation degradation.
+
+See also: `docs/project/integration-standards.md`.
+
+## Automation guardrails
+
+Never use automation to:
+- assume an approval mode that is not explicitly recorded
+- mark work `APPROVED` or `DONE` without the required evidence
+- replace human governance where the process requires human approval
+- bypass milestone review gates when they are part of the delivery model
+- claim production readiness when CI, merge state, or deterministic validation is still missing
+
+Automation may draft artifacts, run reviews, summarize evidence, and complete autonomous bootstrap runs when that mode is explicitly enabled.
+
+## Recommendation-specific standards
+
+- Frame outputs as complete-look and context-aware recommendations, not only similar-item suggestions.
+- Identify the recommendation type and consuming surface when describing behavior.
+- Preserve merchandising control, analytics, and governance in production-facing features.
+- Do not expose sensitive internal profile reasoning directly in customer-facing messaging.
+
+## Missing decisions handling
+
+- Use a dedicated `Missing decisions` section when unresolved choices affect scope, architecture, or delivery.
+- Phrase each missing decision so a later owner can act on it directly.
+- Do not use "TBD" as a substitute for a meaningful missing-decision statement.
+
+## Standards review trigger
+
+Update this standards layer when:
+- new channels or recommendation types change shared assumptions
+- identity, privacy, or governance requirements materially change
+- later feature work exposes a missing cross-cutting standard that affects multiple downstream artifacts

--- a/docs/project/ui-standards.md
+++ b/docs/project/ui-standards.md
@@ -1,0 +1,105 @@
+# UI Standards
+
+## Purpose
+
+Define shared UI standards for customer-facing and internal recommendation experiences powered by the AI Outfit Intelligence Platform.
+
+## Practical usage
+
+Use this document when designing recommendation widgets, look exploration flows, clienteling interfaces, merchandising controls, and analytics-facing admin views.
+
+## UI consistency principles
+
+1. Present recommendations as coherent outfit or complementary decisions, not as an unstructured list of unrelated products.
+2. Make the customer's next action obvious: explore the look, add an item, refine the outfit, or save it.
+3. Preserve a consistent mental model across PDP, cart, homepage, email, and clienteling surfaces.
+4. Show inventory or availability constraints clearly when they affect the recommendation.
+5. Keep explanation cues helpful and brand-safe without exposing overly technical model reasoning.
+
+## Shared experience expectations
+
+### Recommendation presentation
+
+Recommendation UI should clearly communicate:
+- the recommendation type, when relevant
+- the anchor context, such as current product, occasion, or personal relevance
+- the key items in the outfit or recommendation set
+- clear calls to action for add-to-cart, explore, or save flows
+
+### Recommendation card or module anatomy
+
+Where a surface uses cards or modules, include as many of the following as appropriate:
+- look or outfit title
+- primary imagery
+- key included items
+- price summary or price range where useful
+- contextual label such as seasonal, occasion-based, or because-you-bought
+- availability or fallback handling
+
+## Accessibility expectations
+
+- Follow accessible semantic structure for headings, lists, buttons, and grouped recommendation modules.
+- Ensure keyboard navigation works for interactive recommendation items and look builders.
+- Provide meaningful text alternatives for recommendation imagery.
+- Avoid using color alone to communicate recommendation state or priority.
+- Preserve readable loading, empty, and error states for screen-reader users.
+
+## State and feedback patterns
+
+Design explicit states for:
+- loading recommendation modules
+- empty or no-match conditions
+- fallback recommendations when personalization is unavailable
+- unavailable or low-inventory items
+- save, dismiss, or add-to-cart feedback
+- experiment or personalization variants that may alter presentation
+
+Surfaces should fail gracefully. If complete-look recommendations are unavailable, show the best supported fallback rather than a broken container.
+
+## Analytics and telemetry expectations
+
+UI implementations must emit the recommendation telemetry required by `docs/project/data-standards.md`, including impression and downstream interaction events.
+
+At minimum, UI layers should preserve:
+- `recommendationSetId`
+- `traceId`
+- `recommendationType`
+- `surface`
+- relevant `productId` or `lookId`
+
+## Shared component expectations
+
+- Reuse common recommendation module patterns where possible across shopper surfaces.
+- Keep internal and external components aligned on shared metadata even if visual design differs.
+- Do not hard-code channel-specific interpretation of recommendation types that conflicts with API contracts.
+
+## Surface-specific notes
+
+### PDP and cart
+
+- Optimize for quick outfit completion and complementary-item confidence.
+- Keep modules compact enough to support conversion-oriented layouts.
+
+### Homepage and inspiration surfaces
+
+- Allow broader look storytelling and occasion-led discovery.
+- Support more exploratory layouts than PDP or cart.
+
+### Email
+
+- Ensure recommendation content can degrade gracefully when richer interactive behavior is unavailable.
+- Preserve identifiers needed for click-through attribution.
+
+### Clienteling and internal tools
+
+- Show enough recommendation context, rule influence, and customer state to support human judgment.
+- Make overrides or substitutions explicit when supported.
+
+### Merchandising or admin interfaces
+
+- Prioritize clarity of rule impact, preview behavior, and auditability over customer-facing polish.
+
+## Missing decisions
+
+- Missing decision: how much explanatory text should appear on customer-facing surfaces versus only internal tools.
+- Missing decision: whether saved looks and dismiss actions are supported in the first shopper-facing release.

--- a/docs/project/vision.md
+++ b/docs/project/vision.md
@@ -1,0 +1,75 @@
+# Vision
+
+## Purpose
+
+Define why the AI Outfit Intelligence Platform exists, what long-term outcome it should create, and how later planning work should interpret the product's ambition.
+
+## Practical usage
+
+Use this document to:
+- align later business requirements and feature breakdowns to the same product intent
+- keep RTW and CM work pointed at the same complete-look strategy
+- distinguish core differentiators from optional future enhancements
+
+## Product vision
+
+SuitSupply should offer a recommendation experience that helps customers build complete, credible outfits rather than assemble isolated products one item at a time. The platform should combine curated style knowledge, merchandising rules, customer behavior, and real-world context so each recommendation feels stylist-approved and personally relevant.
+
+The platform is not only a storefront recommender. It is a cross-channel outfit intelligence layer that can serve the ecommerce site, clienteling tools, email marketing, and future API-driven surfaces with consistent recommendation logic and measurable outcomes.
+
+## Why this product should exist
+
+SuitSupply already has strong styling expertise, curated looks, and differentiated product quality. That advantage is underused when digital experiences focus on similar-item or co-purchase recommendations. Customers need help answering complete-look questions such as:
+- what shirt matches this suit
+- which tie works with this jacket
+- what to wear for a given occasion, climate, or season
+- how to extend a previous purchase into a full outfit
+
+This product should exist to turn existing style intelligence into a scalable decisioning capability that improves conversion, basket size, repeat engagement, and customer confidence.
+
+## Long-term product ambition
+
+The long-term ambition is to make outfit intelligence a shared platform capability across all customer and stylist touchpoints:
+- online shoppers receive context-aware outfit recommendations in real time
+- returning customers see recommendations shaped by purchase history, style profile, and current intent
+- stylists and client advisors can use the same recommendation engine in assisted selling workflows
+- merchandisers can publish curated looks, rules, and campaign priorities without hard-coding every experience
+- RTW and CM recommendations can be served from a common recommendation platform with mode-specific logic
+
+In the mature state, the platform becomes SuitSupply's operating layer for personalized style guidance rather than a narrow widget on a product page.
+
+## Differentiators
+
+| Differentiator | Why it matters |
+| --- | --- |
+| Complete-look recommendation model | Moves beyond similar products and supports outfit-building decisions across categories. |
+| Hybrid curated plus AI approach | Preserves merchandising control while still allowing data-driven ranking and personalization. |
+| RTW and CM support in one platform | Avoids separate recommendation stacks for standard catalog shopping and configured garments. |
+| Cross-channel delivery | Ensures the same logic can power PDP, cart, homepage, email, clienteling, and future mobile/API surfaces. |
+| Context-aware decisioning | Uses season, weather, location, and occasion signals to improve relevance. |
+| Governed optimization loop | Connects recommendation decisions to telemetry, experimentation, and analytics rather than one-off curation. |
+
+## Intended market and user impact
+
+For customers, success means faster outfit building, higher confidence, and less uncertainty about compatibility, formality, and styling completeness.
+
+For SuitSupply teams, success means:
+- increased conversion and average order value
+- stronger attach rates across shirts, ties, shoes, belts, outerwear, and accessories
+- more usable style intelligence across ecommerce, retail, and CRM channels
+- better control over how AI-ranked recommendations interact with curated looks and campaign priorities
+
+## Strategic product principles
+
+1. **Recommend looks, not only items.** Every major surface should be able to present a coherent outfit, not just adjacent SKUs.
+2. **Keep curation in the loop.** AI ranking should respect curated looks, merchandising rules, and brand styling guardrails.
+3. **Treat context as first-class input.** Recommendation quality should improve when location, weather, season, or occasion signals are available.
+4. **Support both anonymous and known journeys.** The platform should still work without a known customer profile and improve when identity resolution is available.
+5. **Design for measurable optimization.** Recommendation decisions should be explainable, testable, and tied to downstream outcome events.
+6. **Unify RTW and CM where possible.** Shared platform components should be reused while allowing mode-specific compatibility logic.
+
+## Bounded assumptions captured in this vision
+
+- The first usable product should prioritize digitally visible shopper value before deeper automation of every internal workflow.
+- Recommendation experiences should remain brand-safe and merchandiser-governed rather than fully autonomous.
+- Customer-facing explanations should emphasize styling relevance and occasion fit, not opaque model reasoning.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- create the canonical `docs/project/` bootstrap doc set for the AI Outfit Intelligence Platform
- add the required product docs: vision, goals, problem statement, personas, product overview, business requirements, roadmap, architecture overview, and standards
- add optional but clearly needed standards docs for API, data, UI, and integration design
- capture bounded assumptions and explicit missing decisions for later feature and architecture fan-out

## Docs created
- `docs/project/vision.md`
- `docs/project/goals.md`
- `docs/project/problem-statement.md`
- `docs/project/personas.md`
- `docs/project/product-overview.md`
- `docs/project/business-requirements.md`
- `docs/project/roadmap.md`
- `docs/project/architecture-overview.md`
- `docs/project/standards.md`
- `docs/project/api-standards.md`
- `docs/project/data-standards.md`
- `docs/project/ui-standards.md`
- `docs/project/integration-standards.md`

## Notes
- optional supporting docs referenced by the bootstrap wrapper prompt were not present, so the doc set was authored using the repo bootstrap prompts and existing recommendation-domain rules
- no downstream feature specs, board seeding, or issue fan-out were created in this run

## Validation
- reviewed the doc set for required sections, terminology consistency, phase sequencing, and explicit missing-decision handling
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-52c4c33f-c596-4d2c-b2af-285076ac9bb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-52c4c33f-c596-4d2c-b2af-285076ac9bb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

