### PR TITLE
Add initial project documentation bootstrap

### DIFF
--- a/docs/project/api-standards.md
+++ b/docs/project/api-standards.md
@@ -1,0 +1,83 @@
+# API Standards
+
+## Purpose
+
+These standards define the baseline contract expectations for APIs exposed by the Outfit Intelligence Platform, especially recommendation delivery APIs consumed by web, email, clienteling, and future channels.
+
+## 1. API style
+
+- Prefer resource-oriented HTTP APIs with explicit, stable request and response schemas.
+- Recommendation responses should identify recommendation type and intended surface context when relevant.
+- APIs must support partial context gracefully; missing optional inputs should not cause schema instability.
+- Separate request context from recommendation results so consumers can debug and audit responses more easily.
+
+## 2. Baseline endpoint direction
+
+An initial endpoint shape may be:
+
+`GET /recommendations`
+
+Supported request inputs may include:
+
+- customerId
+- productId
+- surface
+- context
+- location
+- weather
+- occasion
+- sessionId
+
+The contract should allow multiple response groups such as:
+
+- outfits
+- crossSell
+- upsell
+- styleBundles
+
+## 3. Contract consistency rules
+
+- Every recommendation object must include stable IDs for the recommendation set and the underlying items or looks.
+- Every response must identify the strategy or variant metadata needed for analytics and experimentation.
+- Product references should use canonical product identifiers rather than only display names.
+- Optional explanation or badge fields must be clearly typed and safe for customer display.
+- Responses must distinguish between unavailable fields and empty recommendation results.
+
+## 4. Versioning
+
+- Version APIs explicitly from the start.
+- Avoid breaking changes within a published version.
+- Additive fields are preferred over schema replacement.
+- Consumer-facing version changes must include deprecation guidance and migration timing once multiple consumers exist.
+
+## 5. Authentication and authorization
+
+- Use channel-appropriate authentication for server-to-server and authenticated customer contexts.
+- Do not expose internal operator-only data on customer-facing endpoints.
+- Authorization must account for region, channel, and role where operator tooling is involved.
+- Sensitive personalization inputs should not be accepted or returned without a documented need and approval path.
+
+## 6. Error model
+
+- Return structured errors with machine-readable codes and human-readable messages.
+- Distinguish validation errors, authentication errors, authorization errors, upstream dependency failures, and empty-result conditions.
+- Empty recommendations should generally be represented as valid responses with empty collections, not transport-level errors.
+- Include trace or correlation identifiers in error responses when operationally safe.
+
+## 7. Latency and resiliency expectations
+
+- Customer-facing recommendation APIs should favor predictable latency over unbounded ranking depth.
+- Timeouts and fallbacks must be defined for optional dependencies such as weather or profile enrichment.
+- The API should degrade to simpler strategies when upstream signals are unavailable rather than failing entirely.
+
+## 8. Observability and analytics requirements
+
+- Each response must carry enough metadata to connect impression and outcome events back to the generating recommendation set.
+- Recommendation set ID, trace ID, variant ID, and strategy source should be available for telemetry.
+- Logging and tracing must avoid exposing raw sensitive customer data unless explicitly authorized and protected.
+
+## 9. Consumer integration expectations
+
+- Consumers own rendering and layout.
+- The API owns recommendation semantics, ranking outputs, and machine-usable metadata.
+- Channel-specific presentation rules should be additive rather than requiring incompatible contracts for each surface.

--- a/docs/project/architecture-overview.md
+++ b/docs/project/architecture-overview.md
@@ -1,0 +1,143 @@
+# Architecture Overview
+
+## Architecture purpose
+
+This document describes the product-level architecture for the Outfit Intelligence Platform. It establishes the major component areas, data flows, integration boundaries, and implementation constraints needed for later feature and system design.
+
+## High-level system view
+
+The platform should be structured as a shared recommendation layer between upstream data sources and downstream customer or operator experiences.
+
+### Core architectural layers
+
+1. **Source systems and data providers**
+   - commerce platforms such as Shopify and OMS
+   - POS and appointment systems
+   - marketing and email systems
+   - contextual providers such as weather and event calendars
+
+2. **Data ingestion and identity layer**
+   - catalog ingestion and normalization
+   - customer and event ingestion
+   - identity resolution across channels
+   - profile and segmentation services
+
+3. **Recommendation intelligence layer**
+   - product relationship graph
+   - outfit graph and curated look store
+   - compatibility and business rules engine
+   - intent detection and context engine
+   - candidate generation and ranking services
+
+4. **Delivery and activation layer**
+   - recommendation delivery API
+   - channel adapters for web, email, and clienteling
+   - experiment and variant assignment support
+
+5. **Operations and governance layer**
+   - merchandising admin interface
+   - analytics and insights
+   - audit trails and diagnostics
+   - monitoring and operational controls
+
+## Representative data flow
+
+1. Product, customer, and event data are ingested from source systems.
+2. Catalog attributes are normalized into a canonical recommendation model.
+3. Customer identities are linked where confidence and consent rules allow.
+4. Curated looks, compatibility rules, and business constraints are stored in platform-managed configuration.
+5. A channel requests recommendations with available context such as customer, product, location, weather, or occasion.
+6. The recommendation engine generates and ranks candidate products or looks using graph relationships, rules, context, and personalization.
+7. Delivery services return a response tailored to the requesting surface.
+8. Impression and outcome events are captured for experimentation, analytics, and model or rule refinement.
+
+## Major subsystems
+
+## 1. Catalog and attribute service
+
+Responsible for ingesting and normalizing product information required for compatibility and recommendation logic, including category, fabric, color, pattern, fit, season, occasion, price tier, imagery, inventory, and RTW or CM attributes.
+
+## 2. Event and session pipeline
+
+Captures browsing, product views, add-to-cart, search, purchase, email engagement, and other behavioral signals. This pipeline must preserve event timestamps, source context, and stable identifiers needed for attribution.
+
+## 3. Identity and customer profile service
+
+Maintains customer profiles, source-system mappings, segmentation inputs, and identity-resolution confidence. This service must support both known-customer and anonymous-session use cases.
+
+## 4. Relationship and outfit intelligence
+
+Maintains product relationships, curated looks, outfit structures, style tags, and compatibility signals. This subsystem is where merchandising knowledge and modeled relationships meet.
+
+## 5. Recommendation engine
+
+Generates recommendation sets for different intents such as complete look, cross-sell, upsell, contextual, and personal recommendation requests. It should support blending:
+
+- curated recommendations
+- rule-based candidate filtering and boosts
+- AI or model-based ranking
+
+## 6. Context engine
+
+Normalizes location, weather, season, holiday, and session context into reusable recommendation features. Context should influence ranking only when the data is timely and operationally justified.
+
+## 7. Delivery API and channel adapters
+
+Exposes recommendation responses to channel consumers using a shared contract. Channel adapters may enforce surface-specific limits, presentation metadata, or fallbacks.
+
+## 8. Merchandising and analytics operations
+
+Provides operator controls for curated looks, rules, campaign priorities, exclusions, experiments, performance reporting, and diagnostics.
+
+## External integrations
+
+- Shopify or equivalent ecommerce systems
+- OMS and order history sources
+- POS, appointment, or store-visit systems
+- ESP or marketing automation platforms
+- analytics platforms
+- optional weather or contextual data providers
+
+## Key technical boundaries
+
+- The platform should generate recommendations, not replace the system of record for products, orders, or customer accounts.
+- Channel applications own presentation; the platform owns recommendation logic and response contracts.
+- Merchandising controls must be first-class inputs, not manual patches outside the platform.
+- Identity resolution confidence must be explicit so low-confidence joins do not silently distort personalization.
+- Inventory and assortment freshness must be accounted for before recommendations are delivered to customer-facing surfaces.
+
+## Operational assumptions
+
+- Early implementations may use rule-heavy logic with curated inputs before deeper model sophistication.
+- Some channels will have richer context than others; the API must handle partial context gracefully.
+- Recommendation requests must degrade safely when customer identity, weather, or other optional signals are unavailable.
+- Cross-channel consistency matters more than perfect feature parity across every surface in the first release.
+
+## Implementation-oriented constraints
+
+- Recommendation contracts must be stable enough for multiple consumers.
+- The system must be instrumented for recommendation-level analytics, experimentation, and auditability from the start.
+- The architecture must support RTW and CM without collapsing their distinct business rules into one generic model.
+- Data freshness, latency, and reliability requirements differ by channel and should be designed as explicit interface constraints later.
+- Governance for privacy, consent, and region-specific data use must be enforceable at the data and delivery layers.
+
+## API direction
+
+The initial architecture should support a recommendation endpoint shape such as:
+
+`GET /recommendations`
+
+Expected request context may include:
+
+- customerId
+- productId
+- context
+- location
+- weather
+
+Expected response groupings may include:
+
+- outfits
+- crossSell
+- upsell
+- styleBundles

--- a/docs/project/business-requirements.md
+++ b/docs/project/business-requirements.md
@@ -1,0 +1,228 @@
+# Business Requirements
+
+## 1. Purpose
+
+Define the business requirements for an AI Outfit Intelligence Platform that enables SuitSupply to recommend complete looks, not just individual products, across ecommerce, email, and in-store assisted-selling channels.
+
+## 2. Scope summary
+
+The platform must support both Ready-to-Wear and Custom Made recommendation experiences and produce recommendation outputs that are style-aware, context-aware, and commercially useful.
+
+## 3. Target users
+
+### Primary users
+
+- online shoppers browsing suits, shirts, shoes, and accessories
+- returning customers with purchase history and style signals
+- customers shopping for specific occasions such as weddings, business meetings, interviews, travel, or seasonal updates
+
+### Secondary users
+
+- in-store stylists and clienteling teams
+- merchandisers curating looks, rules, and campaigns
+- marketing teams running personalized recommendation programs
+- product, analytics, and optimization teams measuring recommendation performance
+
+## 4. Business value
+
+The platform is intended to:
+
+- increase conversion rate
+- increase basket size and average order value
+- increase customer lifetime value
+- improve style inspiration and discovery
+- make recommendations more relevant across channels
+- improve merchandising control while enabling AI-driven personalization
+- differentiate SuitSupply from retailers that rely on similar-product and co-occurrence recommendations only
+
+## 5. Success measures
+
+### Primary outcome measures
+
+- conversion lift of 5% to 10% on recommendation-enabled experiences
+- average order value lift of 10% to 25%
+- stronger engagement with recommendation modules and campaigns
+- improvement in repeat purchase behavior and returning-customer performance
+
+### Operating measures
+
+- recommendation coverage across priority categories and surfaces
+- recommendation latency suitable for interactive surfaces
+- recommendation click-through and downstream add-to-cart rates
+- attach rate for complementary categories such as shirts, ties, shoes, belts, and accessories
+- merchandiser adoption of rule, look, and campaign management workflows
+
+## 6. In-scope requirements
+
+## 6.1 Recommendation outputs
+
+The platform must support:
+
+- outfit recommendations
+- cross-sell recommendations
+- upsell recommendations
+- curated style bundles
+- occasion-based recommendations
+- contextual recommendations
+- personal recommendations based on customer profile and behavior
+
+## 6.2 Recommendation surfaces
+
+The platform must be able to serve recommendations to:
+
+- product detail pages
+- cart
+- homepage and web personalization surfaces
+- style inspiration and look-builder pages
+- email campaigns
+- in-store clienteling interfaces
+- future mobile or API-driven experiences
+
+## 6.3 Input data and signals
+
+The platform must support ingestion and use of:
+
+### Customer signals
+
+- orders from Shopify, OMS, or other commerce systems
+- browsing behavior
+- page views
+- product views
+- add-to-cart events
+- search behavior
+- email engagement
+- loyalty and account behavior
+- store visits and appointments
+- stylist notes where available and permissioned
+- saved looks, favorites, and wishlists where available
+
+### Context signals
+
+- location and country
+- weather
+- season
+- holiday and event calendar
+- useful device or session context
+
+### Product data
+
+- category
+- fabric
+- color
+- pattern
+- fit
+- season
+- occasion
+- style tags
+- price tier
+- inventory
+- imagery
+- RTW and CM attributes
+
+## 6.4 Core platform capabilities
+
+The platform must provide:
+
+- product catalog ingestion
+- customer signal ingestion
+- event pipeline and session tracking
+- identity resolution across channels
+- customer profile service
+- purchase affinity and segmentation
+- intent detection
+- product relationship graph
+- outfit graph or curated look model
+- compatibility rules and business rules
+- recommendation engine
+- context engine
+- recommendation delivery API
+- merchandising rule builder
+- campaign management support
+- recommendation widgets and surface integration support
+- experimentation and A/B testing
+- analytics and insights
+- admin and merchandising interface
+- governance and controls
+- integrations with commerce, POS, marketing, and analytics systems
+
+## 6.5 RTW and CM support
+
+### Ready-to-Wear
+
+The platform must support standard product and outfit recommendations based on product relationships, style compatibility, personalization, and context.
+
+### Custom Made
+
+The platform must support recommendation logic for:
+
+- shirt style pairing
+- tie style pairing
+- color palette guidance
+- fabric combination guidance
+- premium option suggestion
+- compatibility with configured customer garments
+
+RTW and CM may share platform infrastructure but should not be forced into identical recommendation rules or user journeys.
+
+## 7. Workflow requirements
+
+### 7.1 Product-driven recommendation workflow
+
+When a customer views or purchases an anchor product, the platform must generate complementary products that form a coherent look, filtered by compatibility, availability, and business rules.
+
+### 7.2 Occasion workflow
+
+When occasion context is explicit or inferred, the platform must bias toward looks appropriate for the event, dress-code, climate, and season.
+
+### 7.3 Personalization workflow
+
+When customer identity is known with acceptable confidence, the platform must incorporate past purchases, browsing, and stated or inferred style signals into ranking and exclusions.
+
+### 7.4 Assisted-selling workflow
+
+The platform must provide usable recommendation outputs for stylists and clienteling teams while preserving human override capability and visibility into recommendation context.
+
+### 7.5 Merchandising workflow
+
+Authorized operators must be able to create curated looks, define rules, apply exclusions, prioritize campaigns, and audit recommendation behavior without engineering intervention for routine tuning.
+
+## 8. Governance and control requirements
+
+- Merchandising controls must coexist with AI ranking rather than be bypassed by it.
+- Recommendation logic must respect privacy, consent, and regional data-use rules.
+- Recommendation responses must be traceable to input context, applicable rules, and ranking strategy.
+- The platform must support experimentation without making it impossible to explain why a recommendation appeared.
+- Customer-facing experiences must avoid exposing sensitive or overly specific personal reasoning.
+
+## 9. Constraints
+
+- Data quality across commerce, customer, and contextual systems will be uneven and must be handled gracefully.
+- Inventory and assortment changes can invalidate otherwise relevant recommendations.
+- Channel implementations will vary in latency tolerance and available context.
+- CM recommendations may depend on partially configured garments and appointment workflows.
+- External integrations such as weather and marketing systems may have reliability or freshness limits.
+
+## 10. Assumptions
+
+- SuitSupply has or can expose sufficient product attribute data to support compatibility logic.
+- The business is willing to maintain curated looks, rules, or style taxonomies as platform inputs.
+- Customer data used for personalization can be governed in accordance with regional privacy requirements.
+- Recommendation surfaces can consume a shared API contract even if UI implementations differ by channel.
+- Early releases will focus on a subset of categories and surfaces before reaching full channel coverage.
+
+## 11. Out-of-scope items
+
+- Replacing underlying commerce, OMS, POS, or ESP platforms
+- Building a standalone social or editorial content product
+- End-to-end pricing optimization
+- Full inventory planning or supply-chain forecasting
+- Downstream feature decomposition, board seeding, or implementation issue creation in this bootstrap run
+
+## 12. Open questions
+
+- Which surface should be the initial production launch target: PDP, cart, email, or clienteling?
+- What level of real-time weather and location precision is operationally justified for launch?
+- Which customer signals are available at launch with reliable identity resolution and consent coverage?
+- How much merchandiser override should be hard override versus ranking influence?
+- Which CM recommendation scenarios are required in the first release versus later phases?
+- What explanation model, if any, should be exposed to customers and stylists?

--- a/docs/project/data-standards.md
+++ b/docs/project/data-standards.md
@@ -1,0 +1,83 @@
+# Data Standards
+
+## Purpose
+
+These standards define how the Outfit Intelligence Platform should model identifiers, customer and product data, event telemetry, privacy handling, and auditability.
+
+## 1. Canonical identifiers
+
+The platform should maintain stable canonical IDs for:
+
+- products
+- variants or sellable units where needed
+- customers
+- anonymous sessions
+- looks or outfit definitions
+- recommendation sets
+- rules
+- campaigns
+- experiments
+
+Source-system IDs from Shopify, OMS, POS, email, or other systems must be preserved as mappings, not treated as interchangeable canonical identifiers.
+
+## 2. Product data standards
+
+- Product attributes used for recommendation logic must be normalized into a consistent schema.
+- Required recommendation attributes should include category, fabric, color, pattern, fit, season, occasion, style tags, price tier, imagery, inventory status, and RTW or CM classification.
+- Missing attributes must be explicit so recommendation logic can fall back safely instead of assuming defaults.
+- Inventory freshness and assortment availability should be tracked separately from long-lived descriptive attributes.
+
+## 3. Customer and identity standards
+
+- Customer profiles must record source-system mappings and identity resolution confidence.
+- Anonymous and known-customer journeys should be supported without forcing unreliable identity merges.
+- Preference, purchase, browsing, and engagement signals should be timestamped and attributable to a source.
+- Sensitive data beyond recommendation need should not be ingested simply because it is available.
+
+## 4. Event standards
+
+Recommendation telemetry should capture at minimum:
+
+- impression
+- click
+- save
+- add-to-cart
+- purchase
+- dismiss
+- override
+
+Each outcome event should carry:
+
+- recommendationSetId
+- traceId
+- strategy or variant identifier
+- channel or surface
+- product or look references involved
+- timestamp
+- customer or session reference as permitted
+
+## 5. Data quality and consistency rules
+
+- Event timestamps must use a consistent timezone standard.
+- Important enumerations such as recommendation type, surface, and occasion should use controlled vocabularies.
+- Schema evolution must be versioned and documented.
+- Upstream nulls, stale attributes, or conflicting IDs must be handled explicitly, not silently overwritten.
+
+## 6. Privacy and governance
+
+- Personalization data use must respect consent, opt-out, and region-specific rules.
+- Customer-facing experiences should not reveal sensitive inferred attributes or private reasoning.
+- Access to raw customer-level data should follow least-privilege principles.
+- Governance decisions that affect ranking behavior or data use should be auditable.
+
+## 7. Auditability and lineage
+
+- Recommendation outputs must be traceable to the data and configuration used to generate them.
+- Curated looks, rules, and model versions should be versioned or otherwise attributable.
+- Operators should be able to understand whether a recommendation was primarily curated, rule-based, or AI-ranked.
+
+## 8. Freshness expectations
+
+- Inventory and critical assortment signals should refresh frequently enough to avoid recommending unavailable items on customer-facing surfaces.
+- Product taxonomy and descriptive attributes may refresh on a slower cadence, but changes that affect compatibility should be propagated predictably.
+- Customer behavior and session events should be available soon enough to support session-aware and recent-behavior strategies where promised.

--- a/docs/project/goals.md
+++ b/docs/project/goals.md
@@ -1,0 +1,50 @@
+# Goals
+
+## Business goals
+
+- Increase ecommerce conversion by making outfit decisions easier to complete.
+- Increase average order value by expanding purchases from one primary product into a coordinated look.
+- Increase repeat purchase behavior and customer lifetime value through more relevant personalization.
+- Improve the effectiveness of email and clienteling recommendations by grounding them in shared recommendation logic.
+- Preserve merchandising influence while enabling data-driven ranking and experimentation.
+
+## User goals
+
+- Help shoppers understand what to wear with a viewed or purchased item.
+- Help customers build complete looks for specific occasions such as weddings, business meetings, interviews, travel, and seasonal wardrobe updates.
+- Reduce the time and uncertainty involved in pairing items across suits, shirts, shoes, ties, outerwear, and accessories.
+- Reflect each customer's style history, purchase history, and current context where permissioned signals are available.
+- Support both self-service digital journeys and assisted selling by stylists.
+
+## Operational goals
+
+- Establish a reusable recommendation platform rather than isolated one-off widgets.
+- Ingest catalog, customer, and contextual signals into a governed recommendation system.
+- Provide a recommendation delivery API that can serve multiple channels with consistent contracts.
+- Give merchandisers and operators the ability to define curated looks, compatibility rules, exclusions, and campaign overrides.
+- Instrument recommendation impressions, clicks, add-to-cart, purchase, and override outcomes so performance can be measured and improved.
+
+## Success criteria
+
+### Outcome targets
+
+- Conversion rate improvement of 5% to 10% on recommendation-enabled journeys.
+- Average order value improvement of 10% to 25% where complete-look recommendations are surfaced.
+- Higher engagement with recommendation modules across ecommerce, email, and clienteling flows.
+- Stronger repeat purchase behavior and retention among customers exposed to personalized outfit recommendations.
+
+### Product and platform success signals
+
+- Recommendation coverage across primary product categories and key surfaces.
+- Measurable lift from experimentation on recommendation strategies.
+- Stable recommendation latency suitable for customer-facing surfaces.
+- Merchandiser adoption of look curation, rules, and campaign tooling.
+- Clear traceability from recommendation set generation to downstream conversion outcomes.
+
+## Non-goals
+
+- Replacing all human styling judgment with fully autonomous AI.
+- Launching every surface and integration in the first release.
+- Building a general fashion social network or editorial publishing platform.
+- Solving warehouse allocation, pricing optimization, or unrelated merchandising systems in this bootstrap scope.
+- Treating RTW and CM as identical workflows when their recommendation logic or constraints differ.

--- a/docs/project/integration-standards.md
+++ b/docs/project/integration-standards.md
@@ -1,0 +1,60 @@
+# Integration Standards
+
+## Purpose
+
+These standards define how the Outfit Intelligence Platform should integrate with commerce, customer, contextual, marketing, analytics, and assisted-selling systems.
+
+## 1. Integration principles
+
+- Prefer explicit contracts over informal coupling to upstream or downstream systems.
+- Keep the recommendation platform separate from systems of record.
+- Model each integration with clear ownership for identifiers, freshness, retry behavior, and failure handling.
+- Design for partial availability of upstream systems without causing total recommendation failure where fallbacks are possible.
+
+## 2. Expected integration categories
+
+- ecommerce and commerce platforms
+- OMS and order history sources
+- POS, appointment, and store-visit systems
+- ESP or marketing automation platforms
+- analytics and experimentation tools
+- optional context providers such as weather services
+
+## 3. Authentication and secret handling
+
+- Use managed credentials and least-privilege access for all integrations.
+- Do not embed secrets in code, configuration committed to the repository, or client-side payloads.
+- Access scopes should match the minimum data needed for the integration use case.
+- Secret rotation and credential ownership should be defined before production rollout.
+
+## 4. Reliability expectations
+
+- Define retries, timeouts, and circuit-breaking behavior per dependency class.
+- Use idempotent ingestion behavior for event and catalog pipelines wherever practical.
+- Distinguish between hard dependency failures and optional-signal failures such as weather enrichment.
+- Recommendation-serving paths should degrade to simpler strategies when non-critical integrations are unavailable.
+
+## 5. Data ownership and mapping
+
+- Source-system ownership of products, orders, and customer records must remain explicit.
+- Canonical platform IDs should map back to source-system IDs.
+- Mapping logic and transformation rules should be documented for high-impact integrations.
+- Integration-specific enumerations should be normalized into platform vocabularies before recommendation logic depends on them.
+
+## 6. Observability expectations
+
+- Integration health should be observable through logs, metrics, and traces.
+- Failures should be attributable to a dependency, operation, and impacted scope.
+- Data freshness and ingestion lag should be measurable for catalog, event, and customer data sources.
+
+## 7. Dependency management
+
+- New integrations should not be introduced without a defined business use case and ownership model.
+- Channel-specific adapters should reuse shared platform contracts where possible.
+- Integration changes that affect recommendation behavior must be communicated to operators and downstream consumers.
+
+## 8. Compliance and governance
+
+- Regional privacy, consent, and data-sharing constraints must be enforced at integration boundaries.
+- Stylist notes or other sensitive customer inputs require explicit review before operational use in recommendation logic.
+- Third-party context providers should be treated as augmenting signals, not unquestioned sources of truth.

--- a/docs/project/personas.md
+++ b/docs/project/personas.md
@@ -1,0 +1,144 @@
+# Personas
+
+## Primary personas
+
+## 1. Occasion-driven online shopper
+
+### Profile
+
+A customer shopping for a specific event or dress-code outcome such as a wedding, business meeting, interview, travel wardrobe, or seasonal refresh.
+
+### Goals
+
+- Assemble a complete, appropriate outfit quickly.
+- Understand which items match a selected anchor product.
+- Feel confident that the final look suits the event and season.
+
+### Pain points
+
+- Unsure which complementary products work together.
+- Overwhelmed by category choices and styling combinations.
+- Cannot easily translate a high-level occasion into a shoppable look.
+
+### Behaviors and decision context
+
+- Often starts from one anchor item such as a suit or jacket.
+- May browse multiple categories in one session.
+- Responds well to clear outfit suggestions and simple rationale.
+- Needs fast confidence, not a deep styling education flow.
+
+### What success looks like
+
+The customer sees a coherent look, understands why it fits the occasion, and purchases multiple compatible items in one journey.
+
+## 2. Returning relationship shopper
+
+### Profile
+
+A repeat customer with order history, preferences, and known fit or style patterns who expects smarter personalization over time.
+
+### Goals
+
+- Discover new items that fit prior purchases and personal style.
+- Avoid recommendations that duplicate owned products or clash with existing wardrobe choices.
+- Receive recommendations that feel relevant across web, email, and assisted channels.
+
+### Pain points
+
+- Generic recommendations ignore past purchases and stated preferences.
+- Repetitive suggestions make the brand feel less attentive.
+- Cross-channel experiences are inconsistent.
+
+### Behaviors and decision context
+
+- Often responds to replenishment, occasion, or wardrobe-extension needs.
+- May enter through email, direct product pages, or personalized landing experiences.
+- Expects recommendations to reflect purchase history and recency.
+
+### What success looks like
+
+The customer receives personalized looks and cross-sell suggestions that complement owned items and increase confidence in returning to purchase again.
+
+## 3. Style-guided explorer
+
+### Profile
+
+A customer browsing without a single fixed item in mind and looking for inspiration, complete looks, or seasonal guidance.
+
+### Goals
+
+- Explore curated outfits that match personal taste and context.
+- Understand what is new, relevant, and wearable now.
+- Move from inspiration to basket without piecing the outfit together manually.
+
+### Pain points
+
+- Catalog browsing alone does not explain how to build a look.
+- Similar-product widgets do not inspire complete outfit decisions.
+- Context such as weather or location is rarely reflected.
+
+### Behaviors and decision context
+
+- Browses look-builder or inspiration surfaces.
+- May shop seasonally or in response to travel and climate.
+- Is more open to discovery if recommendations are visually and stylistically coherent.
+
+### What success looks like
+
+The customer discovers a look that feels tailored to their context and converts from inspiration into multi-item purchase behavior.
+
+## Secondary personas
+
+## 4. In-store stylist or clienteling associate
+
+### Goals
+
+- Quickly assemble looks for customers in appointments or store visits.
+- Use recommendation support without losing human judgment.
+- See suggestions that account for inventory, occasion, and customer history where available.
+
+### Pain points
+
+- Styling knowledge is not always easy to reuse consistently.
+- Manual look assembly is time-consuming during high-touch selling moments.
+- Digital recommendation systems may not support store-assisted workflows.
+
+### What success looks like
+
+The stylist receives high-quality starting recommendations that accelerate assisted selling while preserving control over the final look.
+
+## 5. Merchandiser and campaign curator
+
+### Goals
+
+- Define curated looks, compatibility rules, exclusions, and campaign priorities.
+- Influence recommendation behavior without manually hardcoding every surface.
+- Balance brand standards with AI-driven relevance.
+
+### Pain points
+
+- Existing recommendation systems often provide weak control or opaque outputs.
+- Curated knowledge does not scale consistently across channels.
+- Overrides and seasonal logic are hard to operationalize cleanly.
+
+### What success looks like
+
+The merchandiser can shape recommendation behavior with traceable rules and curated inputs while still benefiting from automated ranking.
+
+## 6. Marketing, product, and analytics operator
+
+### Goals
+
+- Use recommendation outputs in email and lifecycle programs.
+- Measure performance by strategy, surface, and audience segment.
+- Optimize recommendation behavior through experiments and analysis.
+
+### Pain points
+
+- Recommendation logic differs across channels, making learning inconsistent.
+- Outcome measurement is incomplete or hard to attribute.
+- Optimization depends on manual analysis rather than systematic telemetry.
+
+### What success looks like
+
+The operator can launch recommendation-driven campaigns, measure lift, and use shared platform metrics to improve performance over time.

--- a/docs/project/problem-statement.md
+++ b/docs/project/problem-statement.md
@@ -1,0 +1,64 @@
+# Problem Statement
+
+## Current problem
+
+SuitSupply customers often shop with outfit intent but encounter a buying experience optimized for individual products. A customer may arrive looking for a suit, jacket, or shirt, yet the harder decision is usually how to complete the look:
+
+- which shirt, tie, shoes, and belt work together
+- what is appropriate for a specific occasion
+- which options fit the current weather, season, and location
+- how to choose items that align with the customer's existing wardrobe and style
+
+Without strong complete-look guidance, customers are left to manually evaluate compatibility across categories, price points, and styling conventions.
+
+## Who experiences it
+
+### Primary affected users
+
+- online shoppers browsing suits, shirts, shoes, and accessories
+- returning customers whose past orders and preferences are not fully reflected in recommendations
+- customers shopping for occasion-driven needs such as weddings, interviews, business meetings, travel, or seasonal wardrobe updates
+
+### Secondary affected users
+
+- in-store stylists and clienteling teams who need faster, more consistent outfit suggestions
+- merchandisers who want curated look strategies to scale beyond manual placement
+- marketing teams who need more relevant recommendation content in lifecycle campaigns
+- product and analytics teams responsible for recommendation performance and optimization
+
+## Why current alternatives are insufficient
+
+Typical ecommerce recommendation patterns emphasize:
+
+- similar products
+- frequently bought together combinations
+- top sellers or popularity-based ranking
+- co-occurrence signals without style intelligence
+
+These approaches are insufficient because they do not consistently account for:
+
+- style compatibility across categories
+- outfit-level completeness
+- occasion and dress-code suitability
+- weather, season, and geography
+- customer profile, past purchases, and personal preferences
+- merchandising rules, curated looks, and brand styling intent
+
+## Why now
+
+SuitSupply already has the brand authority, product breadth, and styling knowledge needed to support complete-look recommendations, but that expertise is not yet activated as a unified platform capability. The opportunity is timely because:
+
+- customers increasingly expect personalized and contextual commerce experiences
+- recommendation quality can now improve meaningfully by combining structured product data, behavior signals, and AI ranking
+- SuitSupply operates across ecommerce, email, and in-store channels that would benefit from a shared recommendation foundation
+- the business impact is directly tied to conversion, basket size, and repeat purchase behavior
+
+## Consequence of not solving it
+
+If this problem remains unsolved:
+
+- customers will continue to abandon outfit decisions or settle for incomplete baskets
+- recommendation surfaces will underperform by promoting isolated products instead of coherent looks
+- merchandising knowledge will remain difficult to scale consistently across channels
+- email and clienteling experiences will stay less relevant than they could be
+- SuitSupply will leave measurable revenue and differentiation on the table relative to a more intelligent style-led commerce experience

--- a/docs/project/product-overview.md
+++ b/docs/project/product-overview.md
@@ -1,0 +1,112 @@
+# Product Overview
+
+## What the product is
+
+The AI Outfit Intelligence Platform is a recommendation system for SuitSupply that generates complete-look, cross-sell, upsell, contextual, occasion-based, and personalized recommendations across digital and assisted-selling channels. It combines catalog intelligence, curated merchandising looks, compatibility rules, customer behavior, and real-time context to recommend coordinated outfits rather than isolated products.
+
+The platform must support both:
+
+- Ready-to-Wear (RTW) recommendation journeys
+- Custom Made (CM) recommendation journeys, including guidance for fabrics, palettes, shirt and tie pairings, and premium option selection around configured garments
+
+## Primary channels and surfaces
+
+- product detail pages
+- cart
+- homepage and web personalization surfaces
+- style inspiration and look-builder pages
+- email campaigns
+- in-store clienteling interfaces
+- future mobile or API-driven consumer experiences
+
+## Core recommendation types
+
+- outfit recommendations
+- cross-sell recommendations
+- upsell recommendations
+- curated style bundles
+- occasion-based recommendations
+- contextual recommendations
+- personal recommendations based on customer profile and behavior
+
+## Major user journeys
+
+## 1. Anchor-product outfit completion
+
+A customer views or purchases an anchor item such as a suit, jacket, or shirt and receives compatible items to complete the outfit.
+
+Example outcome:
+
+- navy suit -> white shirt, burgundy tie, brown shoes, matching belt, pocket square
+
+## 2. Occasion-driven look discovery
+
+A customer expresses or implies an occasion such as business formal, wedding guest, travel, or seasonal dressing and receives a pre-coordinated, shoppable look.
+
+## 3. Contextual session-based recommendation
+
+A customer browsing in a specific country, season, or weather context receives recommendations optimized for climate, region, and dress expectations.
+
+Example outcome:
+
+- browsing linen jackets in Italy during summer -> linen suit, lightweight shirt, loafers, summer belt, sunglasses
+
+## 4. Returning-customer wardrobe extension
+
+A known customer receives recommendations that complement prior purchases and inferred preferences rather than generic product similarity suggestions.
+
+## 5. Assisted selling and clienteling support
+
+Stylists and clienteling teams use the same recommendation logic, with room for human override, to assemble and discuss looks with customers.
+
+## Major workflows
+
+### Customer-facing workflow
+
+1. Collect relevant context from session, product, customer, and environment.
+2. Determine recommendation intent such as outfit completion, occasion, upsell, or personal extension.
+3. Generate candidate looks and product combinations from curated looks, compatibility rules, graph relationships, and model-based ranking.
+4. Filter by availability, price context, business rules, and channel constraints.
+5. Return ranked recommendations through a delivery API.
+6. Capture impression and outcome telemetry for measurement and optimization.
+
+### Merchandising and operations workflow
+
+1. Ingest and enrich product catalog data.
+2. Define curated looks, compatibility rules, exclusions, and campaign priorities.
+3. Monitor recommendation performance by type, surface, and customer segment.
+4. Run experiments and adjust rule or ranking strategies.
+
+## Major capability areas
+
+- product catalog ingestion and enrichment
+- customer signal ingestion
+- event pipeline and session tracking
+- identity resolution and customer profile management
+- purchase affinity and segmentation
+- intent detection
+- product relationship graph
+- outfit graph and curated look management
+- compatibility and business rules engine
+- recommendation generation and ranking
+- context engine for location, weather, season, and event signals
+- recommendation delivery API
+- experimentation and analytics
+- merchandising admin and governance controls
+
+## Product boundaries
+
+## In scope at the platform level
+
+- generating recommendation sets for multiple surfaces
+- supporting both RTW and CM recommendation logic
+- enabling curated, rule-based, and AI-ranked recommendation strategies
+- measuring recommendation outcomes and experimentation
+- supporting merchandiser and operator controls
+
+## Out of scope at bootstrap level
+
+- final feature-level implementation plans for each surface
+- downstream issue fan-out or board seeding
+- replacing core commerce, POS, or marketing systems
+- full editorial content management beyond recommendation-oriented look curation

--- a/docs/project/roadmap.md
+++ b/docs/project/roadmap.md
@@ -1,0 +1,186 @@
+# Roadmap
+
+## Roadmap intent
+
+This roadmap defines a phased delivery order for the initial Outfit Intelligence Platform. The sequence prioritizes shared foundations first, then high-value recommendation surfaces, then broader personalization, merchandising maturity, and CM expansion.
+
+## Delivery principles
+
+- Deliver a reusable platform core before expanding channel count.
+- Start with a narrow set of recommendation surfaces that can prove commercial lift quickly.
+- Introduce merchandising governance and analytics early so recommendation quality can be tuned safely.
+- Add deeper personalization and CM support after the data and delivery foundations are stable.
+
+## Phase 0: Foundations and data readiness
+
+### Objectives
+
+- Establish the minimum platform backbone for recommendation generation and measurement.
+- Normalize product, customer, and event data needed for early recommendation use cases.
+- Define core recommendation contracts, identifiers, and telemetry.
+
+### Key themes
+
+- catalog ingestion and attribute normalization
+- customer and event signal ingestion
+- session tracking and identity resolution baseline
+- recommendation delivery API definition
+- product relationship and outfit graph foundation
+- baseline analytics and experimentation instrumentation
+
+### Dependencies
+
+- access to catalog and commerce data
+- initial taxonomy for categories, occasion, style, and season
+- decision on canonical identifiers and event schemas
+
+### Checkpoints
+
+- core catalog and event data can be ingested reliably
+- recommendation response contract is stable enough for channel integration
+- telemetry captures impression, click, add-to-cart, and purchase outcomes
+
+## Phase 1: RTW complete-look recommendations on priority ecommerce surfaces
+
+### Objectives
+
+- Launch the first customer-facing recommendation experiences focused on high-intent RTW journeys.
+- Prove that complete-look recommendations outperform similar-product patterns.
+
+### Recommended first surfaces
+
+- product detail pages
+- cart
+
+### Key themes
+
+- anchor-product outfit completion
+- compatibility filtering and inventory-aware ranking
+- curated looks blended with AI and rules
+- experimentation on recommendation strategy and presentation
+
+### Dependencies
+
+- Phase 0 data, contract, and telemetry foundations
+- initial curated looks and business rules from merchandising
+- availability and assortment filtering from commerce systems
+
+### Checkpoints
+
+- recommendation quality review with merchandising stakeholders
+- live experiments or controlled rollout plan on priority surfaces
+- operational monitoring for latency, empty states, and attach-rate lift
+
+## Phase 2: Contextual personalization and operator tooling
+
+### Objectives
+
+- Improve recommendation relevance through context and customer profile usage.
+- Give operators meaningful control and visibility into recommendation behavior.
+
+### Key themes
+
+- location, season, and weather-aware ranking
+- purchase-affinity and personal recommendation strategies
+- merchandiser rule builder and curated look management
+- campaign management hooks for lifecycle marketing
+- expanded analytics and recommendation diagnostics
+
+### Dependencies
+
+- reliable identity resolution confidence handling
+- approved use of context and customer data by region
+- instrumentation from earlier phases to support learning loops
+
+### Checkpoints
+
+- operator workflows can create and adjust recommendation logic without code changes for routine cases
+- recommendation reporting shows outcomes by type, surface, and segment
+- contextual recommendation quality is validated against merchandising expectations
+
+## Phase 3: Cross-channel activation and email/clienteling delivery
+
+### Objectives
+
+- Reuse platform outputs beyond ecommerce widgets.
+- Extend recommendation value into assisted selling and outbound marketing.
+
+### Key themes
+
+- recommendation delivery for email campaigns
+- clienteling interfaces and stylist support
+- shared recommendation set generation across channels
+- channel-specific presentation constraints and ranking policies
+
+### Dependencies
+
+- stable API and data contracts
+- integration patterns for email and clienteling systems
+- operator controls for campaign or channel-specific rules
+
+### Checkpoints
+
+- recommendation outputs can be consumed consistently by non-web channels
+- measurement supports cross-channel attribution where feasible
+- stylist workflows confirm recommendations are useful as a starting point, not a blocker
+
+## Phase 4: Custom Made and advanced optimization
+
+### Objectives
+
+- Expand recommendation logic to CM-specific decision support.
+- Mature platform optimization, governance, and scale handling.
+
+### Key themes
+
+- CM fabric and styling compatibility
+- premium option suggestions
+- configured-garment-aware recommendations
+- advanced experimentation and ranking optimization
+- deeper governance, auditing, and recommendation explainability
+
+### Dependencies
+
+- clear CM launch scope and data availability
+- integration with CM configuration workflows
+- strong traceability and override handling from prior phases
+
+### Checkpoints
+
+- CM recommendations are validated by domain experts
+- recommendation quality remains explainable despite more advanced ranking logic
+- platform operations can support broader surface and assortment coverage
+
+## What should happen earlier vs later
+
+### Earlier
+
+- foundational data contracts
+- catalog normalization
+- telemetry
+- RTW complete-look use cases on high-intent surfaces
+- baseline merchandising controls
+
+### Later
+
+- broad multi-channel rollout
+- sophisticated weather and contextual ranking depth
+- full CM recommendation breadth
+- advanced optimization and explainability features
+
+## Phase dependencies summary
+
+- Phase 1 depends on Phase 0.
+- Phase 2 depends on production learnings and telemetry from Phase 1.
+- Phase 3 depends on a stable API and operator model from Phases 1 and 2.
+- Phase 4 depends on the shared platform capabilities from earlier phases plus CM-specific integration and domain validation.
+
+## Review and stop-continue checkpoints
+
+At the end of each phase, review:
+
+- recommendation quality versus merchandising expectations
+- business lift signals versus baseline
+- telemetry completeness and attribution reliability
+- operational stability, including latency and empty-result handling
+- whether the next phase can proceed without creating hidden platform debt

--- a/docs/project/standards.md
+++ b/docs/project/standards.md
@@ -1,0 +1,88 @@
+# Standards
+
+## Purpose
+
+These standards define the cross-cutting expectations for documentation, delivery, traceability, terminology, and quality across the Outfit Intelligence Platform workstream.
+
+## 1. Terminology standards
+
+Use consistent language across all future artifacts:
+
+- **Outfit**: the customer-facing complete-look recommendation.
+- **Look**: an internally curated or structured grouping of compatible products.
+- **RTW**: Ready-to-Wear recommendation context.
+- **CM**: Custom Made recommendation context.
+- **Curated**: explicitly defined by merchandisers or stylists.
+- **Rule-based**: determined by deterministic compatibility or business logic.
+- **AI-ranked**: ordered or scored by model-based logic.
+- **Surface**: the consuming experience such as PDP, cart, homepage, email, or clienteling.
+
+Avoid collapsing these terms into generic "recommendations" when the distinction matters for implementation or measurement.
+
+## 2. Documentation standards
+
+- `docs/project/` is the canonical project-level source of truth.
+- Future requirements, architecture, plan, and implementation artifacts must trace back to these bootstrap docs.
+- Documents should be implementation-oriented, concise, and explicit about assumptions and open questions.
+- Do not hide unresolved decisions; record them directly in the relevant artifact.
+- Do not create downstream issue fan-out or board seeding artifacts inside bootstrap documents.
+
+## 3. Traceability standards
+
+- Every later-stage artifact should reference the relevant upstream project docs and the specific scope it derives from.
+- Recommendation types, surfaces, and channel-specific requirements must be traceable from business requirements to architecture and implementation plans.
+- Key assumptions that affect data, privacy, or integration design must remain visible across artifacts until resolved.
+- Changes to terminology or scope must be updated consistently across all canonical docs.
+
+## 4. Delivery and lifecycle standards
+
+- Favor phased delivery over big-bang rollout.
+- Prioritize reusable platform capabilities before channel sprawl.
+- Use experimentation and measurement as release gates for expanding recommendation strategies.
+- Preserve human override and governance paths for merchandising and clienteling workflows.
+- Distinguish bootstrap documentation, business requirements, architecture, implementation planning, build, and QA stages; do not merge them prematurely.
+- Where workflow states are needed in future artifacts or boards, use this lifecycle vocabulary consistently: `TODO`, `IN_PROGRESS`, `NEEDS_REVIEW`, `IN_REVIEW`, `CHANGES_REQUESTED`, `READY_FOR_HUMAN_APPROVAL`, `APPROVED`, `DONE`.
+
+## 5. Quality standards
+
+- Recommendations must be style-compatible, not merely behaviorally co-occurring.
+- Customer-facing recommendations must degrade gracefully when context is missing or low confidence.
+- Inventory, assortment, and business-rule filtering must be applied before recommendations are shown.
+- Empty-state and low-confidence behaviors must be explicitly designed in later implementation work.
+- Analytics must support evaluation by recommendation type, surface, segment, and strategy.
+
+## 6. Governance and safety standards
+
+- Respect regional privacy, consent, and data-use constraints for personalization.
+- Do not expose sensitive customer reasoning in customer-facing explanation text.
+- Maintain auditability for recommendation generation inputs, applicable rules, and ranking strategy.
+- Merchandising rules and overrides must be governed, versioned, and reviewable.
+- Recommendations for assisted-selling channels should support human judgment rather than replace it.
+
+## 7. API, data, UI, and integration expectations
+
+- Shared recommendation APIs should use stable contracts and explicit versioning.
+- Canonical identifiers must exist for products, customers, looks, campaigns, and experiments.
+- Event telemetry must connect recommendation exposures to outcomes such as click, save, add-to-cart, purchase, dismiss, and override.
+- User-facing experiences should present recommendation modules consistently while allowing surface-specific layouts.
+- Integrations with commerce, POS, marketing, and contextual systems must be explicit about ownership, retries, and failure handling.
+
+Detailed standards for each area should live in:
+
+- `api-standards.md`
+- `data-standards.md`
+- `ui-standards.md`
+- `integration-standards.md`
+
+## 8. Naming and structure expectations
+
+- Use clear, business-meaningful names for recommendation types, surfaces, and workflows.
+- Keep channel-specific details out of shared platform naming where possible.
+- Prefer stable identifiers over display names for machine contracts and analytics.
+- Separate product-level concepts from technical implementation details when naming docs and services.
+
+## 9. Review expectations
+
+- Review bootstrap and later-stage artifacts for clarity, completeness, implementation readiness, consistency, dependency correctness, and automation safety.
+- Flag open questions instead of inventing certainty.
+- Promote work only when downstream teams could proceed without guessing on critical scope or interfaces.

--- a/docs/project/ui-standards.md
+++ b/docs/project/ui-standards.md
@@ -1,0 +1,50 @@
+# UI Standards
+
+## Purpose
+
+These standards define how recommendation experiences should behave across user-facing and operator-facing interfaces without prescribing final visual design.
+
+## 1. Experience principles
+
+- Present recommendations as complete-look or clearly labeled recommendation groups, not as ambiguous item grids.
+- Make it easy for customers to understand how to act on a recommendation, including viewing products, adding items, and exploring a full look.
+- Preserve SuitSupply's premium, style-led brand feel through coherent grouping and presentation.
+- Allow human-assisted channels to adapt recommendations without hiding the underlying suggestion context.
+
+## 2. Consistency expectations
+
+- Use consistent naming for recommendation groups such as outfit, cross-sell, upsell, or style bundle.
+- Use a shared pattern for empty states, loading states, and unavailable recommendations across surfaces.
+- Ensure anchor-product context is visible when recommendations are derived from a viewed or purchased item.
+- Where appropriate, distinguish curated looks from algorithmically ranked suggestions.
+
+## 3. Accessibility expectations
+
+- Recommendation modules must be keyboard accessible and screen-reader navigable.
+- Recommendation labels, calls to action, and state changes must be understandable without relying on imagery alone.
+- Visual grouping of a look should not block accessible access to individual item details.
+
+## 4. State and feedback patterns
+
+- Loading states should communicate that recommendations are being prepared without creating layout instability.
+- Empty states should provide a graceful fallback, not a broken or blank container.
+- Customer actions such as add-to-cart, save, or dismiss should provide clear feedback and emit telemetry.
+- When recommendations are influenced by strong context such as occasion or season, the UI may communicate that context if it improves trust and clarity.
+
+## 5. Explanation and trust guidance
+
+- Customer-facing explanation copy should remain simple and style-oriented, not overly technical or invasive.
+- Do not expose sensitive personal reasoning or identity-resolution details.
+- Assisted-selling surfaces may show richer internal context than customer-facing surfaces, but still should not expose unnecessary sensitive data.
+
+## 6. Telemetry expectations
+
+- UI implementations must emit impression events only when recommendations are actually viewable.
+- Click, save, add-to-cart, dismiss, and look-expansion interactions should be tracked consistently.
+- Recommendation set metadata required for attribution must travel with the rendered module and associated actions.
+
+## 7. Shared component expectations
+
+- Recommendation surfaces should reuse component patterns where feasible for cards, look groupings, badges, and calls to action.
+- Surface-specific differences should be deliberate and documented, not accidental drift.
+- Operator-facing interfaces for merchandising should prioritize clarity, editability, and audit visibility over consumer visual patterns.

--- a/docs/project/vision.md
+++ b/docs/project/vision.md
@@ -1,0 +1,40 @@
+# Vision
+
+## Product vision
+
+Build an AI Outfit Intelligence Platform that helps SuitSupply customers assemble complete, purchase-ready looks instead of isolated products. The platform should combine merchandising expertise, product compatibility logic, customer behavior, and real-time context so every recommendation feels stylistically coherent and commercially relevant.
+
+## Why this product should exist
+
+SuitSupply already has strong brand taste, curated styling knowledge, and a broad catalog across suits, shirts, shoes, and accessories. Customers, however, still have to translate that expertise into their own outfit decisions. That gap creates friction at the exact point where a customer is most likely to hesitate:
+
+- choosing complementary items across categories
+- deciding what is appropriate for an occasion
+- understanding seasonal and weather-appropriate options
+- translating prior purchases and style preferences into the next purchase
+
+The product should exist to turn styling knowledge into a scalable platform capability that improves discovery, conversion, basket size, and long-term personalization across every customer channel.
+
+## Long-term ambition
+
+The long-term goal is for Outfit Intelligence to become the recommendation layer used across ecommerce, email, in-store clienteling, and future mobile or API-driven experiences. It should evolve from basic product pairing into a system that can:
+
+- recommend full looks for RTW and CM journeys
+- personalize recommendations using behavior, purchases, and stylist context
+- adapt to location, weather, season, and occasion
+- give merchandisers meaningful control over rules, campaigns, and curated looks
+- provide measurable business lift through experimentation and analytics
+
+## Differentiators
+
+The platform should differentiate SuitSupply from standard retail recommenders by emphasizing:
+
+- complete-look recommendations instead of item similarity alone
+- a hybrid recommendation model that blends curated looks, business rules, and AI ranking
+- support for both Ready-to-Wear and Custom Made experiences
+- consistent recommendation logic across digital and assisted-selling channels
+- strong merchandising governance rather than a black-box-only model
+
+## Intended market and user impact
+
+For customers, the platform should reduce decision fatigue and increase confidence in building an outfit that looks intentional. For stylists and merchandisers, it should make brand knowledge reusable at scale. For the business, it should raise conversion, average order value, engagement, and customer lifetime value while reinforcing SuitSupply's positioning as a style-led brand rather than a commodity retailer.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add the canonical `docs/project/` bootstrap documents for the AI Outfit Intelligence Platform
- capture product vision, goals, problem statement, personas, product overview, business requirements, roadmap, architecture overview, and delivery standards
- add supporting API, data, UI, and integration standards to guide downstream architecture and implementation work

## Testing
- not run (documentation-only changes)

## Notes
- based on GitHub issue #37 master product specification
- optional supporting bootstrap docs were not present in the repository, so the initial project docs were generated directly from the bootstrap prompts and issue body
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0135a365-bf21-4421-aaf9-b5b674b54312"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0135a365-bf21-4421-aaf9-b5b674b54312"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

